### PR TITLE
setUserProperties -> setGlobalUserProperties

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ To add properties that are tracked in every event, you can set properties for a 
 
     var userProperties = {};
     userProperties.key = "value";
-    amplitude.setUserProperties(userProperties);
+    amplitude.setGlobalUserProperties(userProperties);
 
 # Configuration Options #
 


### PR DESCRIPTION
amplitude.setUserProperties doesn't seem to be defined as a method, and gave me a 'function is undefined' error.

setGlobalUserProperties, however, is defined.
