### PR TITLE
Added support for detecting new sessions

### DIFF
--- a/src/amplitude.js
+++ b/src/amplitude.js
@@ -47,6 +47,7 @@ Amplitude.prototype._eventId = 0;
 Amplitude.prototype._sending = false;
 Amplitude.prototype._lastEventTime = null;
 Amplitude.prototype._sessionId = null;
+Amplitude.prototype._newSession = false;
 
 /**
  * Initializes Amplitude.
@@ -106,6 +107,7 @@ Amplitude.prototype.init = function(apiKey, opt_userId, opt_config) {
     this._eventId = localStorage.getItem(LocalStorageKeys.LAST_EVENT_ID) || 0;
     var now = new Date().getTime();
     if (!this._sessionId || !this._lastEventTime || now - this._lastEventTime > this.options.sessionTimeout) {
+      this._newSession = true;
       this._sessionId = now;
       localStorage.setItem(LocalStorageKeys.SESSION_ID, this._sessionId);
     }
@@ -114,6 +116,10 @@ Amplitude.prototype.init = function(apiKey, opt_userId, opt_config) {
   } catch (e) {
     log(e);
   }
+};
+
+Amplitude.prototype.isNewSession = function() {
+  return this._newSession;
 };
 
 Amplitude.prototype.nextEventId = function() {


### PR DESCRIPTION
I've added some simple code to detect if the user is at the beginning of a new session. This allows me, as a web developer, to use the "amplitude.isNewSession()" function to trigger certain tracking behavior only at the beginning of a session.

The use case I'm solving here is capturing utm_* parameters only once (avoiding a back-button problem), tracking referrers, and generally attaching anything we need to in a "Started Session" event -- a key building-block for web application event tracking.