### PR TITLE
reset session id if setting new user id

### DIFF
--- a/src/amplitude-client.js
+++ b/src/amplitude-client.js
@@ -643,6 +643,12 @@ AmplitudeClient.prototype.setDomain = function setDomain(domain) {
  */
 AmplitudeClient.prototype.setUserId = function setUserId(userId) {
   try {
+    // update sessionId if setting new user id
+    // do not update sessionId if anonymous user logging in, or if resetting same user id
+    if (this.options.userId !== undefined && this.options.userId !== null && this.options.userId !== userId){
+      this._sessionId = new Date().getTime();
+    }
+
     this.options.userId = (userId !== undefined && userId !== null && ('' + userId)) || null;
     _saveCookieData(this);
   } catch (e) {


### PR DESCRIPTION
When changing the user, we should reset the session id so that the new user starts a new session.
@blazzy need you to sanity check real quick. We don't want to reset the session id if it's an anonymous user (userid null) logging in. We don't want to reset the session id if they are setting the same userid. Are there any other cases that I'm missing? 