### PR TITLE
add resetSessionId method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+* Add `resetSessionId` method that sets the sessionId to the current time.
+
 ### 4.1.1 (March 22, 2018)
 
 * Fix bug where cookie data such as device id from older releases were not migrated

--- a/src/amplitude-client.js
+++ b/src/amplitude-client.js
@@ -707,6 +707,10 @@ AmplitudeClient.prototype.setSessionId = function setSessionId(sessionId) {
   }
 };
 
+AmplitudeClient.prototype.resetSessionId = function resetSessionId() {
+  this.setSessionId(new Date().getTime());
+};
+
 /**
   * Regenerates a new random deviceId for current user. Note: this is not recommended unless you know what you
   * are doing. This can be used in conjunction with `setUserId(null)` to anonymize users after they log out.


### PR DESCRIPTION
Expose a public `resetSessionId()` method that the customer can call to set the session id to now. This is preferred over updating the setUserId logic which may or may not introduce regressions.