### PR TITLE
Add tracking config

### DIFF
--- a/src/amplitude-client.js
+++ b/src/amplitude-client.js
@@ -897,7 +897,7 @@ AmplitudeClient.prototype._logEvent = function _logEvent(eventType, eventPropert
 
     userProperties = userProperties || {};
     var trackingOptions = _generateApiPropertiesTrackingConfig(this);
-    trackingOptions = Object.keys(trackingOptions).length > 0 ? {trackingOptions: trackingOptions} : {};
+    trackingOptions = Object.keys(trackingOptions).length > 0 ? {tracking_options: trackingOptions} : {};
     apiProperties = merge(trackingOptions, (apiProperties || {}));
     eventProperties = eventProperties || {};
     groups = groups || {};

--- a/src/amplitude-client.js
+++ b/src/amplitude-client.js
@@ -896,7 +896,9 @@ AmplitudeClient.prototype._logEvent = function _logEvent(eventType, eventPropert
     _saveCookieData(this);
 
     userProperties = userProperties || {};
-    apiProperties = merge(apiProperties || {});
+    var trackingOptions = _generateApiPropertiesTrackingConfig(this);
+    trackingOptions = Object.keys(trackingOptions).length > 0 ? {trackingOptions: trackingOptions} : {};
+    apiProperties = merge(trackingOptions, (apiProperties || {}));
     eventProperties = eventProperties || {};
     groups = groups || {};
     var event = {
@@ -949,6 +951,19 @@ AmplitudeClient.prototype._logEvent = function _logEvent(eventType, eventPropert
 
 var _shouldTrackField = function _shouldTrackField(scope, field) {
   return !!scope.options.trackingOptions[field];
+};
+
+var _generateApiPropertiesTrackingConfig = function _generateApiPropertiesTrackingConfig(scope) {
+  // to limit size of config payload, only send fields that have been disabled
+  var fields = ['city', 'country', 'dma', 'ip_address', 'region'];
+  var config = {};
+  for (var i = 0; i < fields.length; i++) {
+    var field = fields[i];
+    if (!_shouldTrackField(scope, field)) {
+      config[field] = false;
+    }
+  }
+  return config;
 };
 
 /**

--- a/src/amplitude-client.js
+++ b/src/amplitude-client.js
@@ -166,12 +166,12 @@ var _parseConfig = function _parseConfig(options, config) {
 
   // validates config value is defined, is the correct type, and some additional value sanity checks
   var parseValidateAndLoad = function parseValidateAndLoad(key) {
-    if (!DEFAULT_OPTIONS.hasOwnProperty(key)) {
+    if (!options.hasOwnProperty(key)) {
       return;  // skip bogus config values
     }
 
     var inputValue = config[key];
-    var expectedType = type(DEFAULT_OPTIONS[key]);
+    var expectedType = type(options[key]);
     if (!utils.validateInput(inputValue, key + ' option', expectedType)) {
       return;
     }
@@ -180,14 +180,16 @@ var _parseConfig = function _parseConfig(options, config) {
     } else if ((expectedType === 'string' && !utils.isEmptyString(inputValue)) ||
         (expectedType === 'number' && inputValue > 0)) {
       options[key] = inputValue;
+    } else if (expectedType === 'object') {
+      _parseConfig(options[key], inputValue);
     }
-   };
+  };
 
-   for (var key in config) {
+  for (var key in config) {
     if (config.hasOwnProperty(key)) {
       parseValidateAndLoad(key);
     }
-   }
+  }
 };
 
 /**
@@ -921,7 +923,6 @@ AmplitudeClient.prototype._logEvent = function _logEvent(eventType, eventPropert
       sequence_number: sequenceNumber, // for ordering events and identifys
       groups: utils.truncate(utils.validateGroups(groups)),
       user_agent: this._userAgent
-      // country: null
     };
 
     if (eventType === Constants.IDENTIFY_EVENT) {

--- a/src/amplitude-client.js
+++ b/src/amplitude-client.js
@@ -67,7 +67,11 @@ AmplitudeClient.prototype.init = function init(apiKey, opt_userId, opt_config, o
   try {
     this.options.apiKey = apiKey;
     this._storageSuffix = '_' + apiKey + this._legacyStorageSuffix;
+
     _parseConfig(this.options, opt_config);
+    var trackingOptions = _generateApiPropertiesTrackingConfig(this);
+    this._apiPropertiesTrackingOptions = Object.keys(trackingOptions).length > 0 ? {tracking_options: trackingOptions} : {};
+
     this.cookieStorage.options({
       expirationDays: this.options.cookieExpiration,
       domain: this.options.domain
@@ -896,8 +900,7 @@ AmplitudeClient.prototype._logEvent = function _logEvent(eventType, eventPropert
     _saveCookieData(this);
 
     userProperties = userProperties || {};
-    var trackingOptions = _generateApiPropertiesTrackingConfig(this);
-    trackingOptions = Object.keys(trackingOptions).length > 0 ? {tracking_options: trackingOptions} : {};
+    var trackingOptions = merge({}, this._apiPropertiesTrackingOptions);
     apiProperties = merge(trackingOptions, (apiProperties || {}));
     eventProperties = eventProperties || {};
     groups = groups || {};

--- a/src/amplitude-client.js
+++ b/src/amplitude-client.js
@@ -4,7 +4,7 @@ import getUtmData from './utm';
 import Identify from './identify';
 import localStorage from './localstorage';  // jshint ignore:line
 import md5 from 'blueimp-md5';
-import assign from 'lodash/assign';
+import merge from 'lodash/merge';
 import Request from './xhr';
 import Revenue from './revenue';
 import type from './type';
@@ -27,7 +27,7 @@ var AmplitudeClient = function AmplitudeClient(instanceName) {
   this._unsentEvents = [];
   this._unsentIdentifys = [];
   this._ua = new UAParser(navigator.userAgent).getResult();
-  this.options = assign({}, DEFAULT_OPTIONS);
+  this.options = merge({}, DEFAULT_OPTIONS);
   this.cookieStorage = new cookieStorage().getStorage();
   this._q = []; // queue for proxied functions before script load
   this._sending = false;
@@ -896,7 +896,7 @@ AmplitudeClient.prototype._logEvent = function _logEvent(eventType, eventPropert
     _saveCookieData(this);
 
     userProperties = userProperties || {};
-    apiProperties = apiProperties || {};
+    apiProperties = merge(apiProperties || {});
     eventProperties = eventProperties || {};
     groups = groups || {};
     var event = {
@@ -906,12 +906,12 @@ AmplitudeClient.prototype._logEvent = function _logEvent(eventType, eventPropert
       event_id: eventId,
       session_id: this._sessionId || -1,
       event_type: eventType,
-      version_name: this.options.versionName || null,
-      platform: this.options.platform,
-      os_name: this._ua.browser.name || null,
-      os_version: this._ua.browser.major || null,
-      device_model: this._ua.os.name || null,
-      language: this.options.language,
+      version_name: _shouldTrackField(this, 'version_name') ? (this.options.versionName || null) : null,
+      platform: _shouldTrackField(this, 'platform') ? this.options.platform : null,
+      os_name: _shouldTrackField(this, 'os_name') ? (this._ua.browser.name || null) : null,
+      os_version: _shouldTrackField(this, 'os_version') ? (this._ua.browser.major || null) : null,
+      device_model: _shouldTrackField(this, 'device_model') ? (this._ua.os.name || null) : null,
+      language: _shouldTrackField(this, 'language') ? this.options.language : null,
       api_properties: apiProperties,
       event_properties: utils.truncate(utils.validateProperties(eventProperties)),
       user_properties: utils.truncate(utils.validateProperties(userProperties)),
@@ -945,6 +945,10 @@ AmplitudeClient.prototype._logEvent = function _logEvent(eventType, eventPropert
   } catch (e) {
     utils.log.error(e);
   }
+};
+
+var _shouldTrackField = function _shouldTrackField(scope, field) {
+  return !!scope.options.trackingOptions[field];
 };
 
 /**

--- a/src/options.js
+++ b/src/options.js
@@ -3,9 +3,15 @@ import language from './language';
 // default options
 export default {
   apiEndpoint: 'api.amplitude.com',
+  batchEvents: false,
   cookieExpiration: 365 * 10,
   cookieName: 'amplitude_id',
+  deviceIdFromUrlParam: false,
   domain: '',
+  eventUploadPeriodMillis: 30 * 1000, // 30s
+  eventUploadThreshold: 30,
+  forceHttps: true,
+  includeGclid: false,
   includeReferrer: false,
   includeUtm: false,
   language: language.language,
@@ -14,15 +20,21 @@ export default {
   platform: 'Web',
   savedMaxCount: 1000,
   saveEvents: true,
+  saveParamsReferrerOncePerSession: true,
   sessionTimeout: 30 * 60 * 1000,
+  trackingOptions: {
+    city: true,
+    device_model: true,
+    dma: true,
+    ip_address: true,
+    language: true,
+    os_name: true,
+    os_version: true,
+    platform: true,
+    region: true,
+    version_name: true
+  },
   unsentKey: 'amplitude_unsent',
   unsentIdentifyKey: 'amplitude_unsent_identify',
   uploadBatchSize: 100,
-  batchEvents: false,
-  eventUploadThreshold: 30,
-  eventUploadPeriodMillis: 30 * 1000, // 30s
-  forceHttps: true,
-  includeGclid: false,
-  saveParamsReferrerOncePerSession: true,
-  deviceIdFromUrlParam: false,
 };

--- a/src/options.js
+++ b/src/options.js
@@ -24,6 +24,7 @@ export default {
   sessionTimeout: 30 * 60 * 1000,
   trackingOptions: {
     city: true,
+    country: true,
     device_model: true,
     dma: true,
     ip_address: true,

--- a/test/amplitude-client.js
+++ b/test/amplitude-client.js
@@ -1142,6 +1142,37 @@ describe('setVersionName', function() {
     });
   });
 
+  describe('logEvent with tracking options', function() {
+
+    var clock;
+
+    beforeEach(function() {
+      clock = sinon.useFakeTimers();
+      var trackingOptions = {
+        city: false,
+        ip_address: false,
+        language: false,
+        platform: false,
+        region: true
+      };
+      amplitude.init(apiKey, null, {trackingOptions: trackingOptions});
+    });
+
+    afterEach(function() {
+      reset();
+      clock.restore();
+    });
+
+    it('should not track language or platform', function() {
+      assert.equal(amplitude.options.trackingOptions.language, false);
+      amplitude.logEvent('Event Type 1');
+      assert.lengthOf(server.requests, 1);
+      var events = JSON.parse(querystring.parse(server.requests[0].requestBody).e);
+      assert.equal(events[0].language, null);
+      assert.equal(events[0].platform, null);
+    });
+  });
+
   describe('logEvent', function() {
 
     var clock;
@@ -1214,6 +1245,14 @@ describe('setVersionName', function() {
       var events = JSON.parse(querystring.parse(server.requests[0].requestBody).e);
       assert.equal(events.length, 1);
       assert.isNotNull(events[0].language);
+    });
+
+    it('should send platform', function() {
+      amplitude.logEvent('Event Should Send Platform');
+      assert.lengthOf(server.requests, 1);
+      var events = JSON.parse(querystring.parse(server.requests[0].requestBody).e);
+      assert.equal(events.length, 1);
+      assert.equal(events[0].platform, 'Web');
     });
 
     it('should accept properties', function() {

--- a/test/amplitude-client.js
+++ b/test/amplitude-client.js
@@ -736,6 +736,23 @@ it ('should load saved events from localStorage new keys and send events', funct
         version_name: true
       });
     });
+
+    it('should pregenerate tracking options for api properties', function() {
+      var trackingOptions = {
+        city: false,
+        ip_address: false,
+        language: false,
+        region: true,
+      };
+
+      var amplitude2 = new AmplitudeClient('new_app');
+      amplitude2.init(apiKey, null, {trackingOptions: trackingOptions});
+
+      assert.deepEqual(amplitude2._apiPropertiesTrackingOptions, {tracking_options: {
+        city: false,
+        ip_address: false
+      }});
+    });
   });
 
   describe('runQueuedFunctions', function() {

--- a/test/amplitude-client.js
+++ b/test/amplitude-client.js
@@ -1182,7 +1182,7 @@ describe('setVersionName', function() {
 
       // verify country is not sent since it matches the default value of true
       assert.deepEqual(events[0].api_properties, {
-        trackingOptions: {
+        tracking_options: {
           city: false,
           ip_address: false,
         }

--- a/test/amplitude-client.js
+++ b/test/amplitude-client.js
@@ -724,6 +724,7 @@ it ('should load saved events from localStorage new keys and send events', funct
       // check config loaded correctly
       assert.deepEqual(amplitude2.options.trackingOptions, {
         city: false,
+        country: true,
         device_model: true,
         dma: true,
         ip_address: false,
@@ -1150,6 +1151,7 @@ describe('setVersionName', function() {
       clock = sinon.useFakeTimers();
       var trackingOptions = {
         city: false,
+        country: true,
         ip_address: false,
         language: false,
         platform: false,
@@ -1165,11 +1167,26 @@ describe('setVersionName', function() {
 
     it('should not track language or platform', function() {
       assert.equal(amplitude.options.trackingOptions.language, false);
+      assert.equal(amplitude.options.trackingOptions.platform, false);
       amplitude.logEvent('Event Type 1');
       assert.lengthOf(server.requests, 1);
       var events = JSON.parse(querystring.parse(server.requests[0].requestBody).e);
       assert.equal(events[0].language, null);
       assert.equal(events[0].platform, null);
+    });
+
+    it('should send trackingOptions in api properties', function() {
+      amplitude.logEvent('Event Type 2');
+      assert.lengthOf(server.requests, 1);
+      var events = JSON.parse(querystring.parse(server.requests[0].requestBody).e);
+
+      // verify country is not sent since it matches the default value of true
+      assert.deepEqual(events[0].api_properties, {
+        trackingOptions: {
+          city: false,
+          ip_address: false,
+        }
+      });
     });
   });
 
@@ -1245,6 +1262,14 @@ describe('setVersionName', function() {
       var events = JSON.parse(querystring.parse(server.requests[0].requestBody).e);
       assert.equal(events.length, 1);
       assert.isNotNull(events[0].language);
+    });
+
+    it('should not send trackingOptions in api properties', function() {
+      amplitude.logEvent('Event Should Not Send Tracking Properties');
+      assert.lengthOf(server.requests, 1);
+      var events = JSON.parse(querystring.parse(server.requests[0].requestBody).e);
+      assert.equal(events.length, 1);
+      assert.deepEqual(events[0].api_properties, {});
     });
 
     it('should send platform', function() {

--- a/test/amplitude-client.js
+++ b/test/amplitude-client.js
@@ -709,6 +709,32 @@ it ('should load saved events from localStorage new keys and send events', funct
       // check request
       assert.lengthOf(server.requests, 0);
     });
+
+    it('should merge tracking options during parseConfig', function() {
+      var trackingOptions = {
+        city: false,
+        ip_address: false,
+        language: false,
+        region: true,
+      };
+
+      var amplitude2 = new AmplitudeClient('new_app');
+      amplitude2.init(apiKey, null, {trackingOptions: trackingOptions});
+
+      // check config loaded correctly
+      assert.deepEqual(amplitude2.options.trackingOptions, {
+        city: false,
+        device_model: true,
+        dma: true,
+        ip_address: false,
+        language: false,
+        os_name: true,
+        os_version: true,
+        platform: true,
+        region: true,
+        version_name: true
+      });
+    });
   });
 
   describe('runQueuedFunctions', function() {


### PR DESCRIPTION
Adding a config option `trackingOptions` that lets people specify any fields they do not want the SDK to track automatically. These fields include things like platform, language, os_version, ip_address, city, etc. Some of those fields aren't actually tracked by the JS SDK (like ip_address, city, etc) but rather on server-side. So we add the config values to the `api_properties` field, and that can be parsed / handled server-side. 