### PR TITLE
fixing the null groupProperties bug that leads to [Amplitude] Error: …

### DIFF
--- a/amplitude.js
+++ b/amplitude.js
@@ -7597,6 +7597,7 @@ AmplitudeClient.prototype._logEvent = function _logEvent(eventType, eventPropert
     apiProperties = merge_1$1(trackingOptions, apiProperties || {});
     eventProperties = eventProperties || {};
     groups = groups || {};
+    groupProperties = groupProperties || {};
     var event = {
       device_id: this.options.deviceId,
       user_id: this.options.userId,


### PR DESCRIPTION
As of the 4.5.1 release, users are receiving an error message in the log:  [Amplitude] Error: invalid properties format. Expecting Javascript object, received null, ignoring.

The cause is a missing sanity check on the groupProperties object.  The other properties object check for a null value, and replace with a {}, but the groupProperties do not.  

This patch simply adds this groupProperties = groupProperties || {} sanity check like the others.
