### PR TITLE
Move final url slash to config so endpoints may end without a slash

### DIFF
--- a/src/amplitude-client.js
+++ b/src/amplitude-client.js
@@ -1262,7 +1262,7 @@ AmplitudeClient.prototype.sendEvents = function sendEvents(callback) {
 
   this._sending = true;
   var protocol = this.options.forceHttps ? 'https' : ('https:' === window.location.protocol ? 'https' : 'http');
-  var url = protocol + '://' + this.options.apiEndpoint + '/';
+  var url = protocol + '://' + this.options.apiEndpoint;
 
   // fetch events to send
   var numEvents = Math.min(this._unsentCount(), this.options.uploadBatchSize);

--- a/src/options.js
+++ b/src/options.js
@@ -2,7 +2,7 @@ import language from './language';
 
 // default options
 export default {
-  apiEndpoint: 'api.amplitude.com',
+  apiEndpoint: 'api.amplitude.com/',
   batchEvents: false,
   cookieExpiration: 365 * 10,
   cookieName: 'amplitude_id',


### PR DESCRIPTION
The current amplitude URL building code enforces that the endpoint ends with a `/`. That prevents users from using some deeper endpoint. This PR moves the last slash to the config so the user can have any ending on it.