### PR TITLE
Add ES Module build: closes #182

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ dist
 *.crt
 *.key
 amplitude.js
+amplitude.esm.js
 amplitude.min.js
 amplitude.nocompat.js
 amplitude.nocompat.min.js

--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,7 @@ README.md: $(SNIPPET_OUT) version
 $(OUT): node_modules $(SRC) package.json rollup.config.js rollup.min.js
 	@$(JSHINT) --verbose $(SRC)
 	@NODE_ENV=production $(ROLLUP) --config rollup.config.js
+	@NODE_ENV=production $(ROLLUP) --config rollup.esm.js
 	@NODE_ENV=production $(ROLLUP) --config rollup.nocompat.js
 	@NODE_ENV=production $(ROLLUP) --config rollup.min.js
 	@NODE_ENV=production $(ROLLUP) --config rollup.nocompat.min.js

--- a/package.json
+++ b/package.json
@@ -10,8 +10,10 @@
   ],
   "repository": "git://github.com/amplitude/amplitude-javascript.git",
   "main": "amplitude.js",
+  "module": "amplitude.esm.js",
   "dependencies": {
     "@amplitude/ua-parser-js": "0.7.20",
+    "@babel/runtime": "^7.3.4",
     "blueimp-md5": "^2.10.0",
     "query-string": "5"
   },
@@ -19,6 +21,7 @@
     "@babel/core": "^7.3.4",
     "@babel/plugin-external-helpers": "^7.2.0",
     "@babel/plugin-proposal-object-rest-spread": "^7.3.4",
+    "@babel/plugin-transform-runtime": "^7.3.4",
     "@babel/preset-env": "^7.3.4",
     "chai": "^4.1.2",
     "date-fns": "^1.30.1",

--- a/rollup.esm.js
+++ b/rollup.esm.js
@@ -1,0 +1,32 @@
+import commonjs from 'rollup-plugin-commonjs';
+import replace from 'rollup-plugin-replace';
+import babel from 'rollup-plugin-babel';
+import json from 'rollup-plugin-json';
+
+export default {
+  input: 'src/index.js',
+  output: {
+    name: 'amplitude',
+    file: 'amplitude.esm.js',
+    format: 'esm',
+  },
+  plugins: [
+    json(),
+    babel({
+      exclude: 'node_modules/**',
+      plugins: [
+        '@babel/plugin-transform-runtime',
+        '@babel/plugin-proposal-object-rest-spread'
+      ],
+      runtimeHelpers: true
+    }),
+    replace({
+      BUILD_COMPAT_SNIPPET: 'false',
+      BUILD_COMPAT_2_0: 'false',
+      BUILD_COMPAT_LOCAL_STORAGE: 'false',
+    }),
+    commonjs({
+      include: "node_modules/**"
+    }),
+  ],
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -478,8 +478,8 @@
 
 "@babel/plugin-transform-runtime@^7.3.4":
   version "7.4.3"
-  resolved "https://zuora.jfrog.io/zuora/api/npm/zuora-npm/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.4.3.tgz#4d6691690ecdc9f5cb8c3ab170a1576c1f556371"
-  integrity sha1-TWaRaQ7NyfXLjDqxcKFXbB9VY3E=
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.4.3.tgz#4d6691690ecdc9f5cb8c3ab170a1576c1f556371"
+  integrity sha512-7Q61bU+uEI7bCUFReT1NKn7/X6sDQsZ7wL1sJ9IYMAO7cI+eg6x9re1cEw2fCRMbbTVyoeUKWSV1M6azEfKCfg==
   dependencies:
     "@babel/helper-module-imports" "^7.0.0"
     "@babel/helper-plugin-utils" "^7.0.0"
@@ -583,8 +583,8 @@
 
 "@babel/runtime@^7.3.4":
   version "7.4.3"
-  resolved "https://zuora.jfrog.io/zuora/api/npm/zuora-npm/@babel/runtime/-/runtime-7.4.3.tgz#79888e452034223ad9609187a0ad1fe0d2ad4bdc"
-  integrity sha1-eYiORSA0IjrZYJGHoK0f4NKtS9w=
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.4.3.tgz#79888e452034223ad9609187a0ad1fe0d2ad4bdc"
+  integrity sha512-9lsJwJLxDh/T3Q3SZszfWOTkk3pHbkmH+3KY+zwIDmsNlxsumuhS2TH3NIpktU4kNvfzy+k3eLT7aTJSPTo0OA==
   dependencies:
     regenerator-runtime "^0.13.2"
 
@@ -2922,8 +2922,8 @@ regenerate@^1.4.0:
 
 regenerator-runtime@^0.13.2:
   version "0.13.2"
-  resolved "https://zuora.jfrog.io/zuora/api/npm/zuora-npm/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz#32e59c9a6fb9b1a4aff09b4930ca2d4477343447"
-  integrity sha1-MuWcmm+5saSv8JtJMMotRHc0NEc=
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz#32e59c9a6fb9b1a4aff09b4930ca2d4477343447"
+  integrity sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA==
 
 regenerator-transform@^0.13.4:
   version "0.13.4"
@@ -3006,10 +3006,17 @@ resolve-url@^0.2.1:
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
   integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
 
-resolve@^1.10.0, resolve@^1.3.2, resolve@^1.8.1:
+resolve@^1.10.0, resolve@^1.3.2:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.10.0.tgz#3bdaaeaf45cc07f375656dfd2e54ed0810b101ba"
   integrity sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==
+  dependencies:
+    path-parse "^1.0.6"
+
+resolve@^1.8.1:
+  version "1.10.1"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.10.1.tgz#664842ac960795bbe758221cdccda61fb64b5f18"
+  integrity sha512-KuIe4mf++td/eFb6wkaPbMDnP6kObCaEtIDuHOUED6MNUo4K670KZUHuuvYPZDxNF0WVLw49n06M2m2dXphEzA==
   dependencies:
     path-parse "^1.0.6"
 
@@ -3192,8 +3199,8 @@ semver@^5.3.0, semver@^5.4.1:
 
 semver@^5.5.1:
   version "5.7.0"
-  resolved "https://zuora.jfrog.io/zuora/api/npm/zuora-npm/semver/-/semver-5.7.0.tgz#790a7cf6fea5459bac96110b29b60412dc8ff96b"
-  integrity sha1-eQp89v6lRZuslhELKbYEEtyP+Ws=
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.0.tgz#790a7cf6fea5459bac96110b29b60412dc8ff96b"
+  integrity sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==
 
 send@0.16.2:
   version "0.16.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -476,6 +476,16 @@
   dependencies:
     regenerator-transform "^0.13.4"
 
+"@babel/plugin-transform-runtime@^7.3.4":
+  version "7.4.3"
+  resolved "https://zuora.jfrog.io/zuora/api/npm/zuora-npm/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.4.3.tgz#4d6691690ecdc9f5cb8c3ab170a1576c1f556371"
+  integrity sha1-TWaRaQ7NyfXLjDqxcKFXbB9VY3E=
+  dependencies:
+    "@babel/helper-module-imports" "^7.0.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+    resolve "^1.8.1"
+    semver "^5.5.1"
+
 "@babel/plugin-transform-shorthand-properties@^7.2.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.2.0.tgz#6333aee2f8d6ee7e28615457298934a3b46198f0"
@@ -570,6 +580,13 @@
     invariant "^2.2.2"
     js-levenshtein "^1.1.3"
     semver "^5.3.0"
+
+"@babel/runtime@^7.3.4":
+  version "7.4.3"
+  resolved "https://zuora.jfrog.io/zuora/api/npm/zuora-npm/@babel/runtime/-/runtime-7.4.3.tgz#79888e452034223ad9609187a0ad1fe0d2ad4bdc"
+  integrity sha1-eYiORSA0IjrZYJGHoK0f4NKtS9w=
+  dependencies:
+    regenerator-runtime "^0.13.2"
 
 "@babel/template@^7.1.0", "@babel/template@^7.1.2", "@babel/template@^7.2.2":
   version "7.2.2"
@@ -2903,6 +2920,11 @@ regenerate@^1.4.0:
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.0.tgz#4a856ec4b56e4077c557589cae85e7a4c8869a11"
   integrity sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==
 
+regenerator-runtime@^0.13.2:
+  version "0.13.2"
+  resolved "https://zuora.jfrog.io/zuora/api/npm/zuora-npm/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz#32e59c9a6fb9b1a4aff09b4930ca2d4477343447"
+  integrity sha1-MuWcmm+5saSv8JtJMMotRHc0NEc=
+
 regenerator-transform@^0.13.4:
   version "0.13.4"
   resolved "https://registry.yarnpkg.com/regenerator-transform/-/regenerator-transform-0.13.4.tgz#18f6763cf1382c69c36df76c6ce122cc694284fb"
@@ -2984,7 +3006,7 @@ resolve-url@^0.2.1:
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
   integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
 
-resolve@^1.10.0, resolve@^1.3.2:
+resolve@^1.10.0, resolve@^1.3.2, resolve@^1.8.1:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.10.0.tgz#3bdaaeaf45cc07f375656dfd2e54ed0810b101ba"
   integrity sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==
@@ -3167,6 +3189,11 @@ semver@^5.3.0, semver@^5.4.1:
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
   integrity sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==
+
+semver@^5.5.1:
+  version "5.7.0"
+  resolved "https://zuora.jfrog.io/zuora/api/npm/zuora-npm/semver/-/semver-5.7.0.tgz#790a7cf6fea5459bac96110b29b60412dc8ff96b"
+  integrity sha1-eQp89v6lRZuslhELKbYEEtyP+Ws=
 
 send@0.16.2:
   version "0.16.2"


### PR DESCRIPTION
This adds a new build output file, `amplitude.esm.js`, which is an [ES Module version](https://rollupjs.org/guide/en#output-format) of `amplitude-js`. It's made for users who are using amplitude-js with their own bundler (webpack, rollup, etc). It carries significant bundle size savings (the ES module build is 53% the size of the nocompat build):

| File                  | Bytes  |
|-----------------------|--------|
| amplitude.js          | 188568 |
| amplitude.esm.js      | 89767  |
| amplitude.nocompat.js | 169096 |