### PR TITLE
Append this._storageSuffix (which includes API key) to unsentKey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 5.7.0 (November 22, 2019)
+* Namespace AsyncStorage with api key to prevent cross domain contamination
+
 ### 5.6.0 (October 21, 2019)
 
 * Drop esm module from package.json to prevent it from being the default build.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Please see our [installation guide](https://amplitude.zendesk.com/hc/en-us/artic
 [![npm version](https://badge.fury.io/js/amplitude-js.svg)](https://badge.fury.io/js/amplitude-js)
 [![Bower version](https://badge.fury.io/bo/amplitude-js.svg)](https://badge.fury.io/bo/amplitude-js)
 
-[5.6.0 - Released on October 21, 2019](https://github.com/amplitude/Amplitude-JavaScript/releases/latest)
+[5.7.0 - Released on November 22, 2019](https://github.com/amplitude/Amplitude-JavaScript/releases/latest)
 
 
 # JavaScript SDK Reference #

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "amplitude-js",
   "author": "Amplitude <support@amplitude.com>",
-  "version": "5.6.0",
+  "version": "5.7.0",
   "license": "MIT",
   "description": "Javascript library for Amplitude Analytics",
   "keywords": [

--- a/src/amplitude-client.js
+++ b/src/amplitude-client.js
@@ -212,8 +212,8 @@ AmplitudeClient.prototype.init = function init(apiKey, opt_userId, opt_config, o
       });
     } else {
       if (this.options.saveEvents) {
-        this._unsentEvents = this._loadSavedUnsentEvents(this.options.unsentKey + this._storageSuffix).concat(this._unsentEvents);
-        this._unsentIdentifys = this._loadSavedUnsentEvents(this.options.unsentIdentifyKey + this._storageSuffix).concat(this._unsentIdentifys);
+        this._unsentEvents = this._loadSavedUnsentEvents(this.options.unsentKey).concat(this._unsentEvents);
+        this._unsentIdentifys = this._loadSavedUnsentEvents(this.options.unsentIdentifyKey).concat(this._unsentIdentifys);
       }
       initFromStorage();
       this.runQueuedFunctions();
@@ -240,7 +240,7 @@ AmplitudeClient.prototype._migrateUnsentEvents = function _migrateUnsentEvents(c
       var unsentIdentifyKey = values[1];
       Promise.all([
         AsyncStorage.setItem(this.options.unsentKey + this._storageSuffix, unsentEventsString),
-        AsyncStorage.setItem(this.options.unsentIdentifyKey + this._storageSuffix, unsentIdentifyKey ),
+        AsyncStorage.setItem(this.options.unsentIdentifyKey + this._storageSuffix, unsentIdentifyKey),
       ]).then(() => {
         Promise.all([
         AsyncStorage.removeItem(this.options.unsentKey),
@@ -248,7 +248,7 @@ AmplitudeClient.prototype._migrateUnsentEvents = function _migrateUnsentEvents(c
         ]).then(cb);
       }).catch((err) => {
         this.options.onError(err);
-      });;
+      });
     }
   }).catch((err) => {
     this.options.onError(err);

--- a/src/amplitude-client.js
+++ b/src/amplitude-client.js
@@ -168,7 +168,7 @@ AmplitudeClient.prototype.init = function init(apiKey, opt_userId, opt_config, o
     if (AsyncStorage) {
       Promise.all([
           AsyncStorage.getItem(this._storageSuffix),
-          AsyncStorage.getItem(this.options.unsentKey),
+          AsyncStorage.getItem(this.options.unsentKey + this._storageSuffix),
           AsyncStorage.getItem(this.options.unsentIdentifyKey),
       ]).then((values) => {
         if (values[0]) {
@@ -702,7 +702,7 @@ AmplitudeClient.prototype._saveReferrer = function _saveReferrer(referrer) {
 AmplitudeClient.prototype.saveEvents = function saveEvents() {
   try {
     if (AsyncStorage) {
-      AsyncStorage.setItem(this.options.unsentKey, JSON.stringify(this._unsentEvents));
+      AsyncStorage.setItem(this.options.unsentKey + this._storageSuffix, JSON.stringify(this._unsentEvents));
     } else {
       this._setInStorage(localStorage, this.options.unsentKey, JSON.stringify(this._unsentEvents));
     }

--- a/src/amplitude-snippet.js
+++ b/src/amplitude-snippet.js
@@ -2,10 +2,10 @@
   var amplitude = window.amplitude || {'_q':[],'_iq':{}};
   var as = document.createElement('script');
   as.type = 'text/javascript';
-  as.integrity = 'sha384-t5vT47el2d0e6uQ1h75P9Lbzo8by6pbk+Rg41Gm4xuTGR+eDLpbWslKUtZMDe9Bj';
+  as.integrity = 'sha384-rSEVPt+HsYVwBs0EY4dB3fOcSZOW9cbAQV2CqsLFDjNbdiNyoXcGruquK0IyWxAZ';
   as.crossOrigin = 'anonymous';
   as.async = true;
-  as.src = 'https://cdn.amplitude.com/libs/amplitude-5.6.0-min.gz.js';
+  as.src = 'https://cdn.amplitude.com/libs/amplitude-5.7.0-min.gz.js';
   as.onload = function() {if(!window.amplitude.runQueuedFunctions) {console.log('[Amplitude] Error: could not load SDK');}};
   var s = document.getElementsByTagName('script')[0];
   s.parentNode.insertBefore(as, s);


### PR DESCRIPTION
Currently, when saving events to AsyncStorage, we we are only using unsentKey as the identifier.
This can cause events from multiple projects to get mixed up. By appending this._storageSuffix,
we are adding more specificity to keep unsent events within the correct project scope.

Addresses: https://github.com/amplitude/Amplitude-JavaScript/issues/203

FYI: no need to do this for web because it is calling `_setInStorage()` which utilizes `this._storageSuffix` already