### PR TITLE
Fix cookies for subdomains setup

### DIFF
--- a/documentation/Amplitude.html
+++ b/documentation/Amplitude.html
@@ -1850,7 +1850,7 @@ This uses src/uuid.js to regenerate the deviceId.
 
 
 <div class="description">
-    Sets a customer domain for the amplitude cookie. Useful if you want to support cross-subdomain tracking.
+    Sets a customer domain for the amplitude cookie. Specified domain will include all subdomains. If you want to disable tracking for subdomains specify an empty string `''`, this will set cookies for the current domain only.
 </div>
 
 
@@ -1972,7 +1972,7 @@ This uses src/uuid.js to regenerate the deviceId.
 
     <h5>Example</h5>
     
-    <pre class="prettyprint"><code>amplitude.setDomain('.amplitude.com');</code></pre>
+    <pre class="prettyprint"><code>amplitude.setDomain('amplitude.com');</code></pre>
 
 
 

--- a/documentation/AmplitudeClient.html
+++ b/documentation/AmplitudeClient.html
@@ -2036,7 +2036,7 @@ This uses src/uuid.js to regenerate the deviceId.
 
 
 <div class="description">
-    Sets a customer domain for the amplitude cookie. Useful if you want to support cross-subdomain tracking.
+    Sets a customer domain for the amplitude cookie. Specified domain will include all subdomains. If you want to disable tracking for subdomains specify an empty string `''`, this will set cookies for the current domain only.
 </div>
 
 
@@ -2156,7 +2156,7 @@ This uses src/uuid.js to regenerate the deviceId.
 
     <h5>Example</h5>
     
-    <pre class="prettyprint"><code>amplitudeClient.setDomain('.amplitude.com');</code></pre>
+    <pre class="prettyprint"><code>amplitudeClient.setDomain('amplitude.com');</code></pre>
 
 
 

--- a/documentation/amplitude-client.js.html
+++ b/documentation/amplitude-client.js.html
@@ -589,10 +589,10 @@ AmplitudeClient.prototype.saveEvents = function saveEvents() {
 };
 
 /**
- * Sets a customer domain for the amplitude cookie. Useful if you want to support cross-subdomain tracking.
+ * Sets a customer domain for the amplitude cookie. Specified domain will include all subdomains. If you want to disable tracking for subdomains specify an empty string `''`, this will set cookies for the current domain only.
  * @public
  * @param {string} domain to set.
- * @example amplitudeClient.setDomain('.amplitude.com');
+ * @example amplitudeClient.setDomain('amplitude.com');
  */
 AmplitudeClient.prototype.setDomain = function setDomain(domain) {
   if (!utils.validateInput(domain, 'domain', 'string')) {

--- a/documentation/amplitude.js.html
+++ b/documentation/amplitude.js.html
@@ -161,11 +161,11 @@ Amplitude.prototype.saveEvents = function saveEvents() {
 };
 
 /**
- * Sets a customer domain for the amplitude cookie. Useful if you want to support cross-subdomain tracking.
+ * Sets a customer domain for the amplitude cookie. Specified domain will include all subdomains. If you want to disable tracking for subdomains specify an empty string `''`, this will set cookies for the current domain only.
  * @public
  * @param {string} domain to set.
  * @deprecated Please use amplitude.getInstance().setDomain(domain);
- * @example amplitude.setDomain('.amplitude.com');
+ * @example amplitude.setDomain('amplitude.com');
  */
 Amplitude.prototype.setDomain = function setDomain(domain) {
   this.getInstance().setDomain(domain);

--- a/src/amplitude-client.js
+++ b/src/amplitude-client.js
@@ -718,10 +718,10 @@ AmplitudeClient.prototype.saveEvents = function saveEvents() {
 };
 
 /**
- * Sets a customer domain for the amplitude cookie. Useful if you want to support cross-subdomain tracking.
+ * Sets a customer domain for the amplitude cookie. Specified domain will include all subdomains. If you want to disable tracking for subdomains specify an empty string `''`, this will set cookies for the current domain only.
  * @public
  * @param {string} domain to set.
- * @example amplitudeClient.setDomain('.amplitude.com');
+ * @example amplitudeClient.setDomain('amplitude.com');
  */
 AmplitudeClient.prototype.setDomain = function setDomain(domain) {
   if (!utils.validateInput(domain, 'domain', 'string')) {

--- a/src/cookie.js
+++ b/src/cookie.js
@@ -48,7 +48,7 @@ const topDomain = (url) => {
   for (let i = 0; i < levels.length; ++i) {
     const cname = '__tld_test__';
     const domain = levels[i];
-    const opts = { domain: '.' + domain };
+    const opts = { domain: domain };
 
     baseCookie.set(cname, 1, opts);
     if (baseCookie.get(cname)) {
@@ -71,7 +71,7 @@ var options = function(opts) {
   _options.expirationDays = opts.expirationDays;
   _options.secure = opts.secure;
 
-  var domain = (!utils.isEmptyString(opts.domain)) ? opts.domain : '.' + topDomain(getLocation().href);
+  var domain = (opts.domain !== undefined) ? opts.domain : topDomain(getLocation().href);
   var token = Math.random();
   _options.domain = domain;
   set('amplitude_test', token);

--- a/src/options.js
+++ b/src/options.js
@@ -17,7 +17,7 @@ export default {
   cookieExpiration: 365 * 10,
   cookieName: 'amplitude_id',
   deviceIdFromUrlParam: false,
-  domain: '',
+  domain: undefined,
   eventUploadPeriodMillis: 30 * 1000, // 30s
   eventUploadThreshold: 30,
   forceHttps: true,


### PR DESCRIPTION
Due to changes made in https://github.com/amplitude/Amplitude-JavaScript/pull/64 it's not possible to disable cookies for subdomains, they're always on.

## Expected behavior
1. `setDomain('example.com')` or `init(..., { domain: 'example.com' });` would set cookies for `example.com` without subdomains
2. `setDomain('')` or `init(..., { domain: '' });` or `init(..., { domain: null });` would set cookies for the current domain without subdomains

## Actual behavior
1. `setDomain('example.com')` or `init(..., { domain: 'example.com' });` sets cookies for `.example.com`.
2. `setDomain('')` or `init(..., { domain: '' });` or `init(..., { domain: null });` is ignored due to non-empty string check [here](https://github.com/amplitude/Amplitude-JavaScript/blob/master/src/cookie.js#L74)

This happens because of the [document.cookie syntax](https://developer.mozilla.org/en-US/docs/Web/API/Document/cookie): `leading dots in domain names are ignored, but browsers may decline to set the cookie containing such dots. If a domain is specified, subdomains are always included.`

## New behavior
1. Docs are updated to reflect the fact that any specified domain will include all subdomains. There's no workaround for that. Trailing dot for cookies domain is useless, may lead to cookies being declined and has been removed.

2. `setDomain('')` or `init(..., { domain: '' });` or `init(..., { domain: null });` sets cookies only for the current domain since `document.cookie=` is called without a specific domain.