### PR TITLE
Fix issue where AsyncStorage can't re-set unsentEventString nor unsen…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 5.7.1 (December 2, 2019)
+* Fix issue where null unsentKey and unsentIdentifyKeys were causing log crashes
+
 ### 5.7.0 (November 22, 2019)
 * Namespace AsyncStorage with api key to prevent cross domain contamination
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "amplitude-js",
   "author": "Amplitude <support@amplitude.com>",
-  "version": "5.7.0",
+  "version": "5.7.1",
   "license": "MIT",
   "description": "Javascript library for Amplitude Analytics",
   "keywords": [

--- a/src/amplitude-client.js
+++ b/src/amplitude-client.js
@@ -254,17 +254,15 @@ AmplitudeClient.prototype._migrateUnsentEvents = function _migrateUnsentEvents(c
 
       if (itemsToSet.length > 0) {
         Promise.all(itemsToSet).then(() => {
-          Promise.all(itemsToRemove).then(cb);
+          Promise.all(itemsToRemove);
         }).catch((err) => {
           this.options.onError(err);
         });
-      } else {
-        cb();
       }
-    } else {
-      cb();
     }
-  }).catch((err) => {
+  })
+  .then(cb)
+  .catch((err) => {
     this.options.onError(err);
   });
 };

--- a/src/amplitude-client.js
+++ b/src/amplitude-client.js
@@ -258,7 +258,11 @@ AmplitudeClient.prototype._migrateUnsentEvents = function _migrateUnsentEvents(c
         }).catch((err) => {
           this.options.onError(err);
         });
+      } else {
+        cb();
       }
+    } else {
+      cb();
     }
   }).catch((err) => {
     this.options.onError(err);


### PR DESCRIPTION
Addresses: https://github.com/amplitude/Amplitude-JavaScript/issues/209

Fix issue where AsyncStorage can't re-set unsentEventString nor unsentIdentifyKey when they are null

As part of migrating unsentEvents, we are appending this._storageSuffix to both the unsentKey and unsentIdentifyKey.
When either one of these is null, AsyncStorage.setItem breaks because it expects strings.
To fix this, I'm only migrating these values if they are valid and not null. It might be an overkill, but I'm also explicitly JSON.stringifying the values.