### PR TITLE
Add feature to deferInitialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 5.8.0 (December 6, 2019)
+* Add support to defer saving an amplitude cookie and logging events until a user has opted in
+
 ### 5.7.1 (December 2, 2019)
 * Fix issue where null unsentKey and unsentIdentifyKeys were causing log crashes
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Please see our [installation guide](https://amplitude.zendesk.com/hc/en-us/artic
 [![npm version](https://badge.fury.io/js/amplitude-js.svg)](https://badge.fury.io/js/amplitude-js)
 [![Bower version](https://badge.fury.io/bo/amplitude-js.svg)](https://badge.fury.io/bo/amplitude-js)
 
-[5.7.1 - Released on December 3, 2019](https://github.com/amplitude/Amplitude-JavaScript/releases/latest)
+[5.8.0 - Released on December 6, 2019](https://github.com/amplitude/Amplitude-JavaScript/releases/latest)
 
 
 # JavaScript SDK Reference #

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "amplitude-js",
   "author": "Amplitude <support@amplitude.com>",
-  "version": "5.7.1",
+  "version": "5.8.0",
   "license": "MIT",
   "description": "Javascript library for Amplitude Analytics",
   "keywords": [

--- a/src/amplitude-client.js
+++ b/src/amplitude-client.js
@@ -773,7 +773,7 @@ AmplitudeClient.prototype.saveEvents = function saveEvents() {
  */
 AmplitudeClient.prototype.setDomain = function setDomain(domain) {
   if (this._shouldDeferCall()) {
-    return this._q.push(['setDomain', domain]);
+    return this._q.push(['setDomain'].concat(Array.prototype.slice.call(arguments, 0)));
   }
 
   if (!utils.validateInput(domain, 'domain', 'string')) {
@@ -802,7 +802,7 @@ AmplitudeClient.prototype.setDomain = function setDomain(domain) {
  */
 AmplitudeClient.prototype.setUserId = function setUserId(userId) {
   if (this._shouldDeferCall()) {
-    return this._q.push(['setUserId', userId]);
+    return this._q.push(['setUserId'].concat(Array.prototype.slice.call(arguments, 0)));
   }
 
   try {
@@ -828,7 +828,7 @@ AmplitudeClient.prototype.setUserId = function setUserId(userId) {
  */
 AmplitudeClient.prototype.setGroup = function(groupType, groupName) {
   if (this._shouldDeferCall()) {
-    return this._q.push(['setGroup', groupType, groupName]);
+    return this._q.push(['setGroup'].concat(Array.prototype.slice.call(arguments, 0)));
   }
 
   if (!this._apiKeySet('setGroup()') || !utils.validateInput(groupType, 'groupType', 'string') ||
@@ -850,7 +850,7 @@ AmplitudeClient.prototype.setGroup = function(groupType, groupName) {
  */
 AmplitudeClient.prototype.setOptOut = function setOptOut(enable) {
   if (this._shouldDeferCall()) {
-    return this._q.push(['setOptOut', enable]);
+    return this._q.push(['setOptOut'].concat(Array.prototype.slice.call(arguments, 0)));
   }
 
   if (!utils.validateInput(enable, 'enable', 'boolean')) {
@@ -891,7 +891,7 @@ AmplitudeClient.prototype.resetSessionId = function resetSessionId() {
   */
 AmplitudeClient.prototype.regenerateDeviceId = function regenerateDeviceId() {
   if (this._shouldDeferCall()) {
-    return this._q.push(['regenerateDeviceId']);
+    return this._q.push(['regenerateDeviceId'].concat(Array.prototype.slice.call(arguments, 0)));
   }
 
   this.setDeviceId(UUID() + 'R');
@@ -907,7 +907,7 @@ AmplitudeClient.prototype.regenerateDeviceId = function regenerateDeviceId() {
   */
 AmplitudeClient.prototype.setDeviceId = function setDeviceId(deviceId) {
   if (this._shouldDeferCall()) {
-    return this._q.push(['setDeviceId', deviceId]);
+    return this._q.push(['setDeviceId'].concat(Array.prototype.slice.call(arguments, 0)));
   }
 
   if (!utils.validateInput(deviceId, 'deviceId', 'string')) {
@@ -934,7 +934,7 @@ AmplitudeClient.prototype.setDeviceId = function setDeviceId(deviceId) {
  */
 AmplitudeClient.prototype.setUserProperties = function setUserProperties(userProperties) {
   if (this._shouldDeferCall()) {
-    return this._q.push(['setUserProperties', userProperties]);
+    return this._q.push(['setUserProperties'].concat(Array.prototype.slice.call(arguments, 0)));
   }
   if (!this._apiKeySet('setUserProperties()') || !utils.validateInput(userProperties, 'userProperties', 'object')) {
     return;
@@ -962,7 +962,7 @@ AmplitudeClient.prototype.setUserProperties = function setUserProperties(userPro
  */
 AmplitudeClient.prototype.clearUserProperties = function clearUserProperties(){
   if (this._shouldDeferCall()) {
-    return this._q.push(['clearUserProperties']);
+    return this._q.push(['clearUserProperties'].concat(Array.prototype.slice.call(arguments, 0)));
   }
 
   if (!this._apiKeySet('clearUserProperties()')) {
@@ -1002,7 +1002,7 @@ var _convertProxyObjectToRealObject = function _convertProxyObjectToRealObject(i
  */
 AmplitudeClient.prototype.identify = function(identify_obj, opt_callback) {
   if (this._shouldDeferCall()) {
-    return this._q.push(['identify', identify_obj, opt_callback]);
+    return this._q.push(['identify'].concat(Array.prototype.slice.call(arguments, 0)));
   }
   if (!this._apiKeySet('identify()')) {
     if (type(opt_callback) === 'function') {
@@ -1037,7 +1037,7 @@ AmplitudeClient.prototype.identify = function(identify_obj, opt_callback) {
 
 AmplitudeClient.prototype.groupIdentify = function(group_type, group_name, identify_obj, opt_callback) {
   if (this._shouldDeferCall()) {
-    return this._q.push(['groupIdentify', group_type, group_name, identify_obj, opt_callback]);
+    return this._q.push(['groupIdentify'].concat(Array.prototype.slice.call(arguments, 0)));
   }
   if (!this._apiKeySet('groupIdentify()')) {
     if (type(opt_callback) === 'function') {
@@ -1093,7 +1093,7 @@ AmplitudeClient.prototype.groupIdentify = function(group_type, group_name, ident
  */
 AmplitudeClient.prototype.setVersionName = function setVersionName(versionName) {
   if (this._shouldDeferCall()) {
-    return this._q.push(['setVersionName', versionName]);
+    return this._q.push(['setVersionName'].concat(Array.prototype.slice.call(arguments, 0)));
   }
 
   if (!utils.validateInput(versionName, 'versionName', 'string')) {
@@ -1256,7 +1256,7 @@ AmplitudeClient.prototype._limitEventsQueued = function _limitEventsQueued(queue
  */
 AmplitudeClient.prototype.logEvent = function logEvent(eventType, eventProperties, opt_callback) {
   if (this._shouldDeferCall()) {
-    return this._q.push(['logEvent', eventType, eventProperties, opt_callback]);
+    return this._q.push(['logEvent'].concat(Array.prototype.slice.call(arguments, 0)));
   }
   return this.logEventWithTimestamp(eventType, eventProperties, null, opt_callback);
 };
@@ -1273,7 +1273,7 @@ AmplitudeClient.prototype.logEvent = function logEvent(eventType, eventPropertie
  */
 AmplitudeClient.prototype.logEventWithTimestamp = function logEvent(eventType, eventProperties, timestamp, opt_callback) {
   if (this._shouldDeferCall()) {
-    return this._q.push(['logEventWithTimestamp', eventType, eventProperties, timestamp, opt_callback]);
+    return this._q.push(['logEventWithTimestamp'].concat(Array.prototype.slice.call(arguments, 0)));
   }
   if (!this._apiKeySet('logEvent()')) {
     if (type(opt_callback) === 'function') {
@@ -1313,7 +1313,7 @@ AmplitudeClient.prototype.logEventWithTimestamp = function logEvent(eventType, e
  */
 AmplitudeClient.prototype.logEventWithGroups = function(eventType, eventProperties, groups, opt_callback) {
   if (this._shouldDeferCall()) {
-    return this._q.push(['logEventWithGroups', eventType, eventProperties, groups, opt_callback]);
+    return this._q.push(['logEventWithGroups'].concat(Array.prototype.slice.call(arguments, 0)));
   }
   if (!this._apiKeySet('logEventWithGroups()')) {
     if (type(opt_callback) === 'function') {
@@ -1350,7 +1350,7 @@ var _isNumber = function _isNumber(n) {
  */
 AmplitudeClient.prototype.logRevenueV2 = function logRevenueV2(revenue_obj) {
   if (this._shouldDeferCall()) {
-    return this._q.push(['logRevenueV2', revenue_obj]);
+    return this._q.push(['logRevenueV2'].concat(Array.prototype.slice.call(arguments, 0)));
   }
 
   if (!this._apiKeySet('logRevenueV2()')) {
@@ -1384,7 +1384,7 @@ if (BUILD_COMPAT_2_0) {
    */
   AmplitudeClient.prototype.logRevenue = function logRevenue(price, quantity, product) {
     if (this._shouldDeferCall()) {
-      return this._q.push(['logRevenue', price, quantity, product]);
+      return this._q.push(['logRevenue'].concat(Array.prototype.slice.call(arguments, 0)));
     }
 
     // Test that the parameters are of the right type.
@@ -1611,9 +1611,9 @@ AmplitudeClient.prototype._shouldDeferCall = function _shouldDeferCall() {
  * have accepted terms for tracking
  * @private
  */
-AmplitudeClient.prototype._deferInitialization = function _deferInitialization(apiKey, opt_userId, opt_config, opt_callback) {
+AmplitudeClient.prototype._deferInitialization = function _deferInitialization() {
   this._initializationDeferred = true;
-  this._q.push(['init', apiKey, opt_userId, opt_config, opt_callback]);
+  this._q.push(['init'].concat(Array.prototype.slice.call(arguments, 0)));
 };
 
 /**

--- a/src/amplitude-client.js
+++ b/src/amplitude-client.js
@@ -75,15 +75,15 @@ AmplitudeClient.prototype.init = function init(apiKey, opt_userId, opt_config, o
     return;
   }
 
-  var hasExistingCookie = !!this.cookieStorage.get(this.options.cookieName + this._storageSuffix);
-  if (opt_config && opt_config.deferInitialization && !hasExistingCookie) {
-    this._deferInitialization(apiKey, opt_userId, opt_config, opt_callback);
-    return;
-  }
-
   try {
     this.options.apiKey = apiKey;
     this._storageSuffix = '_' + apiKey + this._legacyStorageSuffix;
+
+    var hasExistingCookie = !!this.cookieStorage.get(this.options.cookieName + this._storageSuffix);
+    if (opt_config && opt_config.deferInitialization && !hasExistingCookie) {
+      this._deferInitialization(apiKey, opt_userId, opt_config, opt_callback);
+      return;
+    }
 
     _parseConfig(this.options, opt_config);
 
@@ -1619,10 +1619,12 @@ AmplitudeClient.prototype._deferInitialization = function _deferInitialization(a
 /**
  * Enable tracking via logging events and dropping a cookie
  * Intended to be used with the deferInitialization configuration flag
+ * This will drop a cookie and reset initialization deferred
  * @public
  */
 AmplitudeClient.prototype.enableTracking = function enableTracking() {
   // This will call init (which drops the cookie) and will run any pending tasks
+  this._initializationDeferred = false;
   _saveCookieData(this);
   this.runQueuedFunctions();
 };

--- a/src/amplitude-snippet.js
+++ b/src/amplitude-snippet.js
@@ -2,10 +2,10 @@
   var amplitude = window.amplitude || {'_q':[],'_iq':{}};
   var as = document.createElement('script');
   as.type = 'text/javascript';
-  as.integrity = 'sha384-Ik1BT1T0ZKcBQi93L3Lh8pYLQvUANkj37BjU140rtlIwQSj9ePR4dOoqfWj9u5qU';
+  as.integrity = 'sha384-vYYnQ3LPdp/RkQjoKBTGSq0X5F73gXU3G2QopHaIfna0Ct1JRWzwrmEz115NzOta';
   as.crossOrigin = 'anonymous';
   as.async = true;
-  as.src = 'https://cdn.amplitude.com/libs/amplitude-5.7.1-min.gz.js';
+  as.src = 'https://cdn.amplitude.com/libs/amplitude-5.8.0-min.gz.js';
   as.onload = function() {if(!window.amplitude.runQueuedFunctions) {console.log('[Amplitude] Error: could not load SDK');}};
   var s = document.getElementsByTagName('script')[0];
   s.parentNode.insertBefore(as, s);
@@ -23,7 +23,7 @@
   for (var j = 0; j < revenueFuncs.length; j++) {proxy(Revenue, revenueFuncs[j]);}
   amplitude.Revenue = Revenue;
   var funcs = ['init', 'logEvent', 'logRevenue', 'setUserId', 'setUserProperties',
-               'setOptOut', 'setVersionName', 'setDomain', 'setDeviceId',
+               'setOptOut', 'setVersionName', 'setDomain', 'setDeviceId', 'enableTracking',
                'setGlobalUserProperties', 'identify', 'clearUserProperties',
                'setGroup', 'logRevenueV2', 'regenerateDeviceId', 'groupIdentify', 'onInit',
                'logEventWithTimestamp', 'logEventWithGroups', 'setSessionId', 'resetSessionId'];

--- a/test/amplitude-client.js
+++ b/test/amplitude-client.js
@@ -3331,4 +3331,69 @@ describe('setVersionName', function() {
       assert.equal(cookieStorage.get(amplitude2.options.cookieName + '_' + apiKey).sessionId, newSessionId);
     });
   });
+
+  describe('deferInitialization config', function () {
+    beforeEach(function () {
+      reset();
+      amplitude.init(apiKey, null, { cookieExpiration: 365, deferInitialization: true });
+    });
+
+    describe('prior to opting into analytics', function () {
+      it('should not initially drop a cookie if deferInitialization is set to true', function () {
+        var cookieData = cookie.get(amplitude.options.cookieName + '_' + apiKey);
+        assert.isNull(cookieData);
+      });
+      it('should not send anything to amplitude', function () {
+        amplitude.identify(new Identify().set('prop1', 'value1'));
+        amplitude.logEvent('Event Type 1');
+        amplitude.setDomain('.foobar.com');
+        amplitude.setUserId(123456);
+        amplitude.setGroup('orgId', 15);
+        amplitude.setOptOut(true);
+        amplitude.regenerateDeviceId();
+        amplitude.setDeviceId('deviceId');
+        amplitude.setUserProperties({'prop': true, 'key': 'value'});
+        amplitude.clearUserProperties();
+        amplitude.groupIdentify(null, null, new amplitude.Identify().set('key', 'value'));
+        amplitude.setVersionName('testVersionName1');
+        amplitude.logEventWithTimestamp('test', null, 2000, null);
+        amplitude.logEventWithGroups('Test', {'key': 'value' }, {group: 'abc'});
+        amplitude.logRevenue(10.10);
+
+        var revenue = new amplitude.Revenue().setProductId('testProductId').setQuantity(15).setPrice(10.99);
+        revenue.setRevenueType('testRevenueType').setEventProperties({'city': 'San Francisco'});
+        amplitude.logRevenueV2(revenue);
+
+        assert.lengthOf(server.requests, 0, 'should not send any requests to amplitude');
+        assert.lengthOf(amplitude._unsentEvents, 0, 'should not queue events to be sent')
+      });
+    });
+
+    describe('upon to opting into analytics', function () {
+      it('should drop a cookie', function () {
+        amplitude.enableTracking();
+        var cookieData = cookie.get(amplitude.options.cookieName + '_' + apiKey);
+        assert.isNotNull(cookieData);
+      });
+      it('should send pending calls and events', function () {
+        amplitude.identify(new Identify().set('prop1', 'value1'));
+        amplitude.logEvent('Event Type 1');
+        amplitude.logEvent('Event Type 2');
+        amplitude.logEventWithTimestamp('test', null, 2000, null);
+        amplitude.enableTracking();
+
+        var events = JSON.parse(queryString.parse(server.requests[0].requestBody).e);
+        assert.lengthOf(events, 1, 'should have sent a request to Amplitude');
+        assert.lengthOf(amplitude._unsentEvents, 3, 'should have saved the remaining events')
+      });
+      it('should not continue to deferInitialization if an amplitude cookie exists', function () {
+        amplitude.enableTracking();
+        amplitude.init(apiKey, null, { cookieExpiration: 365, deferInitialization: true });
+        amplitude.logEvent('Event Type 1');
+
+        var events = JSON.parse(queryString.parse(server.requests[0].requestBody).e);
+        assert.lengthOf(events, 1, 'should have sent a request to Amplitude');
+      });
+    });
+  })
 });

--- a/test/amplitude-client.js
+++ b/test/amplitude-client.js
@@ -3369,7 +3369,7 @@ describe('setVersionName', function() {
       });
     });
 
-    describe('upon to opting into analytics', function () {
+    describe('upon opting into analytics', function () {
       it('should drop a cookie', function () {
         amplitude.enableTracking();
         var cookieData = cookie.get(amplitude.options.cookieName + '_' + apiKey);
@@ -3380,11 +3380,27 @@ describe('setVersionName', function() {
         amplitude.logEvent('Event Type 1');
         amplitude.logEvent('Event Type 2');
         amplitude.logEventWithTimestamp('test', null, 2000, null);
+        assert.lengthOf(amplitude._unsentEvents, 0, 'should not have any pending events to be sent');
         amplitude.enableTracking();
 
+        assert.lengthOf(server.requests, 1, 'should have sent a request to Amplitude');
         var events = JSON.parse(queryString.parse(server.requests[0].requestBody).e);
         assert.lengthOf(events, 1, 'should have sent a request to Amplitude');
         assert.lengthOf(amplitude._unsentEvents, 3, 'should have saved the remaining events')
+      });
+      it('should send new events', function () {
+        assert.lengthOf(amplitude._unsentEvents, 0, 'should start with no pending events to be sent');
+        amplitude.identify(new Identify().set('prop1', 'value1'));
+        amplitude.logEvent('Event Type 1');
+        amplitude.logEvent('Event Type 2');
+        amplitude.logEventWithTimestamp('test', null, 2000, null);
+        assert.lengthOf(amplitude._unsentEvents, 0, 'should not have any pending events to be sent');
+
+        amplitude.enableTracking();
+        assert.lengthOf(amplitude._unsentEvents, 3, 'should have saved the remaining events')
+
+        amplitude.logEvent('Event Type 3');
+        assert.lengthOf(amplitude._unsentEvents, 4, 'should save the new events')
       });
       it('should not continue to deferInitialization if an amplitude cookie exists', function () {
         amplitude.enableTracking();


### PR DESCRIPTION
This is especially useful when you don't want to track any analytics or drop any analytic cookies prior to asking the users to opt in to analytics.
I've added a configuration (`deferInitialization`) and an API (`enableTracking`) to manage this.
If deferInitialization is set to true AND a customer has yet to opt in, we will locally store their pending logs until they either navigate away or opt in.

Note: This is a little gross because I'm checking whether or not to defer calling the function in EVERY public function. I considered using js decorators but it would require refactoring this to use classes. I considered iterating over an array of public methods and wrapping them, but that makes debugging much more difficult in the future. Ultimately, I opted for readability.