### PR TITLE
Fix language option type bug

### DIFF
--- a/src/language.js
+++ b/src/language.js
@@ -4,5 +4,5 @@ var getLanguage = function() {
 };
 
 export default {
-    language: getLanguage()
+    getLanguage
 };

--- a/src/language.js
+++ b/src/language.js
@@ -1,6 +1,6 @@
 var getLanguage = function() {
     return (navigator && ((navigator.languages && navigator.languages[0]) ||
-        navigator.language || navigator.userLanguage)) || undefined;
+        navigator.language || navigator.userLanguage)) || '';
 };
 
 export default {

--- a/src/options.js
+++ b/src/options.js
@@ -24,7 +24,7 @@ export default {
   includeGclid: false,
   includeReferrer: false,
   includeUtm: false,
-  language: language.language,
+  language: language.getLanguage(),
   logLevel: 'WARN',
   optOut: false,
   onError: () => {},

--- a/test/language.js
+++ b/test/language.js
@@ -1,7 +1,73 @@
 import language from '../src/language.js';
 
 describe('language', function() {
+    var languagesStub, languageStub, userLanguageStub;
+
+    before(function() {
+        /* Sinon is unable to stub undefined properties so let's make sure all are defined
+           https://github.com/sinonjs/sinon/pull/1557 */
+        if (!('languages' in navigator)) {
+            Object.defineProperty(navigator, 'languages', { 
+                value: null, 
+                configurable: true 
+            });
+        }
+        if (!('language' in navigator)) {
+            Object.defineProperty(navigator, 'language', { 
+                value: null, 
+                configurable: true 
+            });
+        }
+        if (!('userLanguage' in navigator)) {
+            Object.defineProperty(navigator, 'userLanguage', { 
+                value: null, 
+                configurable: true 
+            });
+        }
+
+        languagesStub = sinon.stub(navigator, 'languages').value(['some-locale', 'some-other-locale']);
+        languageStub = sinon.stub(navigator, 'language').value('some-second-locale');
+        userLanguageStub = sinon.stub(navigator, 'userLanguage').value('some-third-locale');
+    });
+
+    afterEach(function () {
+        languagesStub.reset();
+        languageStub.reset();
+        userLanguageStub.reset();
+    });
+
+    after(function () {
+        languagesStub.restore();
+        languageStub.restore();
+        userLanguageStub.restore();
+    });
+
     it('should return a language', function() {
-        assert.isNotNull(language.language);
+        assert.isNotNull(language.getLanguage());
+    });
+
+    it('should prioritize the first language of navigator.languages', function() {      
+        assert.equal(language.getLanguage(), 'some-locale');
+    });
+
+    it('should secondly use the language of navigator.language', function() {   
+        languagesStub.value(undefined);
+   
+        assert.equal(language.getLanguage(), 'some-second-locale');
+    });
+
+    it('should thirdly use the language of navigator.userLanguage', function() {   
+        languagesStub.value(undefined);
+        languageStub.value(undefined);
+
+        assert.equal(language.getLanguage(), 'some-third-locale');
+    });
+
+    it('should return empty string if browser language is not set', function() {
+        languagesStub.value(undefined);
+        languageStub.value(undefined);
+        userLanguageStub.value(undefined);
+
+        assert.equal(language.getLanguage(), '');
     });
 });

--- a/test/language.js
+++ b/test/language.js
@@ -63,7 +63,7 @@ describe('language', function() {
         assert.equal(language.getLanguage(), 'some-third-locale');
     });
 
-    it('should return empty string if browser language is not set', function() {
+    it('should return empty string if navigator language is not set', function() {
         languagesStub.value(undefined);
         languageStub.value(undefined);
         userLanguageStub.value(undefined);


### PR DESCRIPTION
When `window.navigator` is undefined at bootstrap (i.e. react native), the default `language` option will be `undefined`. When then trying to override that at init, the type check in [`parseConfig`]( https://github.com/amplitude/Amplitude-JavaScript/blob/master/src/amplitude-client.js#L309 ) will check the type against `"undefined"` instead of `"string"`. Because of that it's impossible to set the user/device language.

I did not want to change the way the option type checking works, so I changed the default fallback of `getLanguage()` to empty string.

I also took the time to improve unit testing of the `getLanguage()` function.

Open for other ways of solving this! Thank you :) 