### PR TITLE
More compact cookie storage with the option to use local storage

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -19,6 +19,7 @@ export default {
   USER_ID: 'amplitude_userId',
 
   COOKIE_TEST: 'amplitude_cookie_test',
+  COOKIE_PREFIX: "amp",
 
   // revenue keys
   REVENUE_EVENT: 'revenue_amount',

--- a/src/cookie.js
+++ b/src/cookie.js
@@ -3,6 +3,7 @@
  */
 
 import Base64 from './base64';
+import Constants from './constants';
 import utils from './utils';
 import getLocation from './get-location';
 import baseCookie from './base-cookie';
@@ -27,7 +28,12 @@ const getHost = (url) => {
   return a.hostname || location.hostname; 
 };
 
+let _topDomain = '';
+
 const topDomain = (url) => {
+  if (_topDomain) {
+    return topDomain;
+  }
   const host = getHost(url);
   const parts = host.split('.');
   const last = parts[parts.length - 1];
@@ -121,6 +127,20 @@ var set = function(name, value) {
   }
 };
 
+var setRaw = function(name, value) {
+  try {
+    baseCookie.set(_domainSpecific(name), value, _options);
+    return true;
+  } catch (e) {
+    return false;
+  }
+};
+
+var getRaw = function(name) {
+  var nameEq = _domainSpecific(name) + '=';
+  return baseCookie.get(nameEq);
+};
+
 
 var remove = function(name) {
   try {
@@ -131,10 +151,34 @@ var remove = function(name) {
   }
 };
 
+let _areCookiesEnabled = null;
+
+// test that cookies are enabled - navigator.cookiesEnabled yields false positives in IE, need to test directly
+const areCookiesEnabled = () => {
+  if (_areCookiesEnabled !== null) {
+    return _areCookiesEnabled;
+  }
+  var uid = String(new Date());
+  var result;
+  try {
+    set(Constants.COOKIE_TEST, uid);
+    _areCookiesEnabled = get(Constants.COOKIE_TEST) === uid;
+    remove(Constants.COOKIE_TEST);
+    return result;
+  } catch (e) {
+    // cookies are not enabled
+  }
+  return false;
+};
+
 export default {
   reset,
   options,
+  topDomain,
   get,
   set,
-  remove
+  remove,
+  areCookiesEnabled,
+  setRaw,
+  getRaw
 };

--- a/src/metadataStorage.js
+++ b/src/metadataStorage.js
@@ -1,0 +1,78 @@
+/*
+ * Persist SDK event metadata
+ * Uses cookie if available, otherwise fallback to localstorage.
+ */
+
+import Base64 from './base64';
+import Cookie from './cookie';
+import baseCookie from './base-cookie';
+import localStorage from './localstorage'; // jshint ignore:line
+
+class MetadataStorage {
+  constructor({storageKey, disableCookies, domain, secure, sameSite, expirationDays}) {
+    this.storageKey = storageKey;
+    this.disableCookieStorage = !Cookie.areCookiesEnabled() || disableCookies;
+    this.domain = domain;
+    this.secure = secure;
+    this.sameSite = sameSite;
+    this.expirationDays = expirationDays;
+    this.topDomain = domain || Cookie.topDomain();
+  }
+
+  getCookieStorageKey() {
+    return `${this.storageKey}${this.domain ? `_${this.domain}` : ''}`;
+  }
+
+  save({ deviceId, userId, optOut, sessionId, lastEventTime, eventId, identifyId, sequenceNumber }) {
+    // do not change the order of these items
+    const value = `${deviceId}.${Base64.encode(userId || '')}.${optOut ? '1' : ''}.${sessionId}.${lastEventTime}.${eventId}.${identifyId}.${sequenceNumber}`;
+
+    if (this.disableCookieStorage) {
+      localStorage.setItem(this.storageKey, value);
+    } else {
+      baseCookie.set(
+        this.getCookieStorageKey(),
+        value,
+        { domain: this.topDomain, secure: this.secure, sameSite: this.sameSite, expirationDays: this.expirationDays }
+      );
+    }
+  }
+
+  load() {
+    let str;
+    if (!this.disableCookieStorage) {
+      str = baseCookie.get(this.getCookieStorageKey() + '=');
+    }
+    if (!str) {
+      str = localStorage.getItem(this.storageKey);
+    }
+
+    if (!str) {
+      return null;
+    }
+
+    const values = str.split('.');
+
+    let userId = null;
+    if (values[1]) {
+      try {
+        userId = Base64.decode(values[1]);
+      } catch (e) {
+        userId = null;
+      }
+    }
+
+    return {
+      deviceId: values[0],
+      userId,
+      optOut: values[2] === '1',
+      sessionId: parseInt(values[3], 10),
+      lastEventTime: parseInt(values[4], 10),
+      eventId: parseInt(values[5], 10),
+      identifyId: parseInt(values[6], 10),
+      sequenceNumber: parseInt(values[7], 10)
+    };
+  }
+}
+
+export default MetadataStorage;

--- a/src/options.js
+++ b/src/options.js
@@ -15,8 +15,11 @@ export default {
   apiEndpoint: 'api.amplitude.com',
   batchEvents: false,
   cookieExpiration: 365 * 10,
-  cookieName: 'amplitude_id',
+  cookieName: 'amplitude_id', // this is a deprecated option
   sameSiteCookie: 'None',
+  cookieForceUpgrade: false,
+  deferInitialization: false,
+  disableCookies: false,
   deviceIdFromUrlParam: false,
   domain: '',
   eventUploadPeriodMillis: 30 * 1000, // 30s

--- a/test/browser/index.html
+++ b/test/browser/index.html
@@ -30,14 +30,9 @@
       <a href="./snippet.html">snippet tests</a>
       <span>Run the snippet unit tests in your browser</span>
     </div>
-    <div class="row">
-      <a href="./playground.html">require js</a>
-      <span>Playground</span>
-    </div>
     <a href="amplitudejs-requirejs.html">require js</a>
     <a href="amplitudejs-segment.html">segment </a>
     <a href="amplitudejs.html">amplitude js</a>
-    <a href="amplitudejs2.html">amplitude js 2</a>
   </div>
 </body>
 </html>

--- a/test/mock-cookie.js
+++ b/test/mock-cookie.js
@@ -12,7 +12,7 @@ export const mockCookie = () => {
   document.__defineSetter__('cookie', function (str) {
     const indexEquals = str.indexOf("=");
     const key = str.substr(0, indexEquals);
-    const remainingStr = str.substring(str + 1);
+    const remainingStr = str.substring(key.length + 1);
     const splitSemi = remainingStr.split(';').map((str)=> str.trim());
 
     rawCookieData[key] = {


### PR DESCRIPTION
Cookies had this fancy abstraction to mimic local storage. This led to
excessively large cookies.

Rather than storing a large JSON serialized version of the cookie data
we'll now use positional values.

Base64 encoding also led to considerable cookie bloat. Instead we only
Base64 encode the user id field and assume other fields in the cookie
are safe.

You can also forgo using cookie storage altogether with the
disableCookie option. This prevents tracking users across different
subdomains of your site.