### PR TITLE
Use iife for snippet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,7 @@ $(OUT): node_modules $(SRC) package.json rollup.config.js rollup.min.js rollup.n
 	@$(JSHINT) --verbose $(SRC)
 	@NODE_ENV=production $(ROLLUP) --config rollup.config.js
 	@NODE_ENV=production $(ROLLUP) --config rollup.esm.js
+	@NODE_ENV=production $(ROLLUP) --config rollup.umd.js
 	@NODE_ENV=production $(ROLLUP) --config rollup.native.js
 	@NODE_ENV=production $(ROLLUP) --config rollup.nocompat.js
 	@NODE_ENV=production $(ROLLUP) --config rollup.min.js

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "amplitude-js",
   "description": "Javascript library for Amplitude Analytics",
-  "main": "amplitude.js",
+  "main": "amplitude.umd.js",
   "authors": [
     "Amplitude <support@amplitude.com>"
   ],

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "amplitude-js",
   "author": "Amplitude <support@amplitude.com>",
-  "version": "5.11.0",
+  "version": "5.12.0",
   "license": "MIT",
   "description": "Javascript library for Amplitude Analytics",
   "keywords": [
@@ -9,7 +9,7 @@
     "amplitude"
   ],
   "repository": "git://github.com/amplitude/amplitude-javascript.git",
-  "main": "amplitude.js",
+  "main": "amplitude.umd.js",
   "react-native": "amplitude.native.js",
   "dependencies": {
     "@amplitude/ua-parser-js": "0.7.20",

--- a/rollup.umd.js
+++ b/rollup.umd.js
@@ -9,7 +9,7 @@ export default {
   output: {
     name: 'amplitude',
     file: 'amplitude.js',
-    format: 'iife',
+    format: 'umd',
     amd: {
       id: 'amplitude',
     }

--- a/src/amplitude-snippet.js
+++ b/src/amplitude-snippet.js
@@ -2,10 +2,10 @@
   var amplitude = window.amplitude || {'_q':[],'_iq':{}};
   var as = document.createElement('script');
   as.type = 'text/javascript';
-  as.integrity = 'sha384-XjqOOyFvYU+vG4+WrAuiEGo7iwlPziIAukUSiFSme/Jj5Rdk1G9Fu5iMmjxg4XRk';
+  as.integrity = 'sha384-AGAP8hLFGmWct8CISyv9W0dsAYlj/1X7y99zLRAMPI8HANfyBrMgg8CMmBs+jPsZ';
   as.crossOrigin = 'anonymous';
   as.async = true;
-  as.src = 'https://cdn.amplitude.com/libs/amplitude-5.11.0-min.gz.js';
+  as.src = 'https://cdn.amplitude.com/libs/amplitude-5.12.0-min.gz.js';
   as.onload = function() {if(!window.amplitude.runQueuedFunctions) {console.log('[Amplitude] Error: could not load SDK');}};
   var s = document.getElementsByTagName('script')[0];
   s.parentNode.insertBefore(as, s);


### PR DESCRIPTION
Use an iife module for the amplitude snippet. The UMD module has trouble when loaded on sites using require js.

We'll provide a separate UMD file for folks wishing to load the SDK as a require js module.