### PR TITLE
Invoke logEvent callbacks for each event when events are actually sent

### DIFF
--- a/test/amplitude-client.js
+++ b/test/amplitude-client.js
@@ -450,8 +450,8 @@ describe('AmplitudeClient', function() {
       amplitude2.init(apiKey, null, {batchEvents: true});
 
       // check event loaded into memory
-      assert.deepEqual(amplitude2._unsentEvents, JSON.parse(existingEvent));
-      assert.deepEqual(amplitude2._unsentIdentifys, JSON.parse(existingIdentify));
+      assert.deepEqual(amplitude2._unsentEvents.map(({event}) => event), JSON.parse(existingEvent));
+      assert.deepEqual(amplitude2._unsentIdentifys.map(({event}) => event), JSON.parse(existingIdentify));
 
       // check local storage keys are still same for default instance
       assert.equal(localStorage.getItem('amplitude_unsent_' + apiKey), existingEvent);
@@ -479,8 +479,8 @@ describe('AmplitudeClient', function() {
       amplitude2.init(apiKey, null, {batchEvents: true});
 
       // check event loaded into memory
-      assert.deepEqual(amplitude2._unsentEvents, JSON.parse(existingEvent));
-      assert.deepEqual(amplitude2._unsentIdentifys, JSON.parse(existingIdentify));
+      assert.deepEqual(amplitude2._unsentEvents.map(({event}) => event), JSON.parse(existingEvent));
+      assert.deepEqual(amplitude2._unsentIdentifys.map(({event}) => event), JSON.parse(existingIdentify));
 
       // check local storage keys are still same
       assert.equal(localStorage.getItem('amplitude_unsent_' + apiKey +'_new_app'), existingEvent);
@@ -516,8 +516,8 @@ describe('AmplitudeClient', function() {
       }
 
       // check that event loaded into memory
-      assert.deepEqual(amplitude2._unsentEvents[0].event_properties, {});
-      assert.deepEqual(amplitude2._unsentEvents[1].event_properties, expected);
+      assert.deepEqual(amplitude2._unsentEvents[0].event.event_properties, {});
+      assert.deepEqual(amplitude2._unsentEvents[1].event.event_properties, expected);
     });
 
     it('should validate user properties when loading saved identifys from localStorage', function() {
@@ -545,7 +545,7 @@ describe('AmplitudeClient', function() {
       }
 
       // check that event loaded into memory
-      assert.deepEqual(amplitude2._unsentIdentifys[0].user_properties, {'$set': expected});
+      assert.deepEqual(amplitude2._unsentIdentifys[0].event.user_properties, {'$set': expected});
     });
 
     it ('should load saved events from localStorage and send events for default instance', function() {
@@ -660,8 +660,8 @@ it ('should load saved events from localStorage new keys and send events', funct
       }
 
       // check that event loaded into memory
-      assert.deepEqual(amplitude2._unsentEvents[0].event_properties, {});
-      assert.deepEqual(amplitude2._unsentEvents[1].event_properties, expected);
+      assert.deepEqual(amplitude2._unsentEvents[0].event.event_properties, {});
+      assert.deepEqual(amplitude2._unsentEvents[1].event.event_properties, expected);
     });
 
     it('should not load saved events from another instances\'s localStorage', function() {
@@ -895,12 +895,12 @@ describe('setVersionName', function() {
       amplitude.init(apiKey, null, {batchEvents: true});
       amplitude.setVersionName('testVersionName1');
       amplitude.logEvent('testEvent1');
-      assert.equal(amplitude._unsentEvents[0].version_name, 'testVersionName1');
+      assert.equal(amplitude._unsentEvents[0].event.version_name, 'testVersionName1');
 
       // should ignore non-string values
       amplitude.setVersionName(15000);
       amplitude.logEvent('testEvent2');
-      assert.equal(amplitude._unsentEvents[1].version_name, 'testVersionName1');
+      assert.equal(amplitude._unsentEvents[1].event.version_name, 'testVersionName1');
     });
   });
 
@@ -1527,7 +1527,10 @@ describe('setVersionName', function() {
 
       var amplitude2 = new AmplitudeClient();
       amplitude2.init(apiKey);
-      assert.deepEqual(amplitude2._unsentEvents, amplitude._unsentEvents);
+      assert.deepEqual(
+        amplitude2._unsentEvents.map(({event}) => event),
+        amplitude._unsentEvents.map(({event}) => event)
+      );
     });
 
     it('should not save events', function() {
@@ -1592,7 +1595,7 @@ describe('setVersionName', function() {
       assert.lengthOf(server.requests, 1);
       var unsentEvents = amplitude._unsentEvents;
       assert.lengthOf(unsentEvents, 5);
-      assert.deepEqual(unsentEvents[4].event_properties, {index: 14});
+      assert.deepEqual(unsentEvents[4].event.event_properties, {index: 14});
 
       // remaining 5 events should be sent by the delayed sendEvent call
       clock.tick(eventUploadPeriodMillis);
@@ -1812,9 +1815,6 @@ describe('setVersionName', function() {
       };
       amplitude.logEvent('test', null, callback);
       assert.lengthOf(server.requests, 0);
-      assert.equal(counter, 1);
-      assert.equal(value, 0);
-      assert.equal(message, 'No request sent');
 
       // check that request is made after delay, but callback is not run a second time
       clock.tick(eventUploadPeriodMillis);
@@ -1822,6 +1822,8 @@ describe('setVersionName', function() {
       server.respondWith('success');
       server.respond();
       assert.equal(counter, 1);
+      assert.equal(value, 200);
+      assert.equal(message, 'success');
     });
 
     it ('should run callback once and only after all events are uploaded', function () {
@@ -1915,22 +1917,44 @@ describe('setVersionName', function() {
       assert.equal(message, 'success');
     });
 
-    it ('should run callback if server returns something other than 200 and 413', function () {
-      var counter = 0;
-      var value = -1;
-      var message = '';
-      var callback = function (status, response) {
-        counter++;
-        value = status;
-        message = response;
-      };
+    it ('should _not_ run callback when the server returns a 500', function () {
+      const callback = sinon.spy();
 
       amplitude.logEvent('test', null, callback);
-      server.respondWith([404, {}, 'Not found']);
+      server.respondWith([500, {}, 'Not found']);
       server.respond();
-      assert.equal(counter, 1);
-      assert.equal(value, 404);
-      assert.equal(message, 'Not found');
+      assert.isFalse(callback.calledOnce);
+    });
+
+    it('should run the callback when the server finally returns a 200 after a 500', function () {
+      const callback = sinon.spy();
+
+      amplitude.logEvent('test', null, callback);
+      server.respondWith([500, {}, 'Not found']);
+      server.respond();
+      // The SDK retries failed events when a new event is sent
+      amplitude.logEvent('test2');
+      server.respondWith([200, {}, 'success']);
+      server.respond();
+
+      assert.isTrue(callback.calledOnce);
+    });
+
+    it('should run the callback when the server finally returns a 413 after a 500', function () {
+      const callback = sinon.spy();
+
+      amplitude.logEvent('test', null, callback);
+      server.respondWith([500, {}, 'Not found']);
+      server.respond();
+      // The SDK retries failed events when a new event is sent
+      amplitude.logEvent('test2');
+      server.respondWith([413, {}, '']);
+      server.respond();
+      // The SDK will try to shrink the payload in half until its down to one event before giving up
+      server.respondWith([413, {}, '']);
+      server.respond();
+
+      assert.isTrue(callback.calledOnce);
     });
 
     it('should send 3 identify events', function() {
@@ -2097,7 +2121,7 @@ describe('setVersionName', function() {
 
       amplitude.identify(new Identify().add('photoCount', 1));
       amplitude.logEvent('test');
-      delete amplitude._unsentEvents[0].sequence_number; // delete sequence number to simulate old event
+      delete amplitude._unsentEvents[0].event.sequence_number; // delete sequence number to simulate old event
       amplitude._sequenceNumber = 1; // reset sequence number
       amplitude.identify(new Identify().add('photoCount', 2));
 
@@ -2297,7 +2321,7 @@ describe('setVersionName', function() {
       amplitude.init(apiKey, null, {batchEvents: true});
       amplitude.identify(identify);
 
-      assert.deepEqual(amplitude._unsentIdentifys[0].user_properties, {'$set': {'10': 10}});
+      assert.deepEqual(amplitude._unsentIdentifys[0].event.user_properties, {'$set': {'10': 10}});
     });
 
     it('should ignore event and user properties with too many items', function() {
@@ -2347,14 +2371,14 @@ describe('setVersionName', function() {
       amplitude1.logEvent('test5');
 
       // the event ids should all be sequential since amplitude1 and amplitude2 have synchronized cookies
-      var eventId = amplitude1._unsentEvents[0]['event_id'];
-      assert.equal(amplitude2._unsentEvents[0]['event_id'], eventId + 1);
-      assert.equal(amplitude1._unsentEvents[1]['event_id'], eventId + 2);
-      assert.equal(amplitude2._unsentEvents[1]['event_id'], eventId + 3);
+      var eventId = amplitude1._unsentEvents[0].event['event_id'];
+      assert.equal(amplitude2._unsentEvents[0].event['event_id'], eventId + 1);
+      assert.equal(amplitude1._unsentEvents[1].event['event_id'], eventId + 2);
+      assert.equal(amplitude2._unsentEvents[1].event['event_id'], eventId + 3);
 
-      var sequenceNumber = amplitude1._unsentEvents[0]['sequence_number'];
-      assert.equal(amplitude2._unsentIdentifys[0]['sequence_number'], sequenceNumber + 4);
-      assert.equal(amplitude1._unsentEvents[2]['sequence_number'], sequenceNumber +  5);
+      var sequenceNumber = amplitude1._unsentEvents[0].event['sequence_number'];
+      assert.equal(amplitude2._unsentIdentifys[0].event['sequence_number'], sequenceNumber + 4);
+      assert.equal(amplitude1._unsentEvents[2].event['sequence_number'], sequenceNumber +  5);
     });
 
     it('should handle groups input', function() {
@@ -2362,6 +2386,7 @@ describe('setVersionName', function() {
       var value = -1;
       var message = '';
       var callback = function (status, response) {
+        console.log('called callback', status, response);
         counter++;
         value = status;
         message = response;

--- a/test/amplitude.js
+++ b/test/amplitude.js
@@ -121,12 +121,12 @@ describe('Amplitude', function() {
       assert.lengthOf(app2._unsentEvents, 1);
       assert.lengthOf(app2._unsentIdentifys, 0);
 
-      assert.deepEqual(amplitude.getInstance()._unsentEvents[0].event_type, 'amplitude event');
-      assert.deepEqual(amplitude.getInstance()._unsentEvents[1].event_type, 'amplitude event2');
+      assert.deepEqual(amplitude.getInstance()._unsentEvents[0].event.event_type, 'amplitude event');
+      assert.deepEqual(amplitude.getInstance()._unsentEvents[1].event.event_type, 'amplitude event2');
       assert.deepEqual(amplitude.getInstance()._unsentIdentifys, []);
       assert.deepEqual(app1._unsentEvents, []);
-      assert.deepEqual(app1._unsentIdentifys[0].user_properties, {'$set':{'key':'value'}});
-      assert.deepEqual(app2._unsentEvents[0].event_type, 'app2 event');
+      assert.deepEqual(app1._unsentIdentifys[0].event.user_properties, {'$set':{'key':'value'}});
+      assert.deepEqual(app2._unsentEvents[0].event.event_type, 'app2 event');
       assert.deepEqual(app2._unsentIdentifys, []);
 
       assert.equal(amplitude.getInstance()._eventId, 2);
@@ -331,8 +331,8 @@ describe('Amplitude', function() {
       amplitude2.init(apiKey, null, {batchEvents: true});
 
       // check event loaded into memory
-      assert.deepEqual(amplitude2.getInstance()._unsentEvents, JSON.parse(existingEvent));
-      assert.deepEqual(amplitude2.getInstance()._unsentIdentifys, JSON.parse(existingIdentify));
+      assert.deepEqual(amplitude2.getInstance()._unsentEvents.map(({event}) => event), JSON.parse(existingEvent));
+      assert.deepEqual(amplitude2.getInstance()._unsentIdentifys.map(({event}) => event), JSON.parse(existingIdentify));
 
       // check local storage keys are still same for default instance
       assert.equal(localStorage.getItem('amplitude_unsent_' + apiKey), existingEvent);
@@ -368,8 +368,8 @@ describe('Amplitude', function() {
       }
 
       // check that event loaded into memory
-      assert.deepEqual(amplitude2.getInstance()._unsentEvents[0].event_properties, {});
-      assert.deepEqual(amplitude2.getInstance()._unsentEvents[1].event_properties, expected);
+      assert.deepEqual(amplitude2.getInstance()._unsentEvents[0].event.event_properties, {});
+      assert.deepEqual(amplitude2.getInstance()._unsentEvents[1].event.event_properties, expected);
     });
 
     it('should validate user properties when loading saved identifys from localStorage', function() {
@@ -397,7 +397,7 @@ describe('Amplitude', function() {
       }
 
       // check that event loaded into memory
-      assert.deepEqual(amplitude2.getInstance()._unsentIdentifys[0].user_properties, {'$set': expected});
+      assert.deepEqual(amplitude2.getInstance()._unsentIdentifys[0].event.user_properties, {'$set': expected});
     });
 
     it ('should load saved events from localStorage new keys and send events', function() {
@@ -476,8 +476,8 @@ describe('Amplitude', function() {
       }
 
       // check that event loaded into memory
-      assert.deepEqual(amplitude2.getInstance()._unsentEvents[0].event_properties, {});
-      assert.deepEqual(amplitude2.getInstance()._unsentEvents[1].event_properties, expected);
+      assert.deepEqual(amplitude2.getInstance()._unsentEvents[0].event.event_properties, {});
+      assert.deepEqual(amplitude2.getInstance()._unsentEvents[1].event.event_properties, expected);
     });
   });
 
@@ -631,12 +631,12 @@ describe('setVersionName', function() {
       amplitude.init(apiKey, null, {batchEvents: true});
       amplitude.setVersionName('testVersionName1');
       amplitude.logEvent('testEvent1');
-      assert.equal(amplitude.getInstance()._unsentEvents[0].version_name, 'testVersionName1');
+      assert.equal(amplitude.getInstance()._unsentEvents[0].event.version_name, 'testVersionName1');
 
       // should ignore non-string values
       amplitude.setVersionName(15000);
       amplitude.logEvent('testEvent2');
-      assert.equal(amplitude.getInstance()._unsentEvents[1].version_name, 'testVersionName1');
+      assert.equal(amplitude.getInstance()._unsentEvents[1].event.version_name, 'testVersionName1');
     });
   });
 
@@ -1003,7 +1003,10 @@ describe('setVersionName', function() {
 
       var amplitude2 = new Amplitude();
       amplitude2.init(apiKey);
-      assert.deepEqual(amplitude2.getInstance()._unsentEvents, amplitude.getInstance()._unsentEvents);
+      assert.deepEqual(
+        amplitude2.getInstance()._unsentEvents.map(({event}) => event),
+        amplitude.getInstance()._unsentEvents.map(({event}) => event)
+      );
     });
 
     it('should not save events', function() {
@@ -1068,7 +1071,7 @@ describe('setVersionName', function() {
       assert.lengthOf(server.requests, 1);
       var unsentEvents = amplitude.getInstance()._unsentEvents;
       assert.lengthOf(unsentEvents, 5);
-      assert.deepEqual(unsentEvents[4].event_properties, {index: 14});
+      assert.deepEqual(unsentEvents[4].event.event_properties, {index: 14});
 
       // remaining 5 events should be sent by the delayed sendEvent call
       clock.tick(eventUploadPeriodMillis);
@@ -1288,15 +1291,14 @@ describe('setVersionName', function() {
       };
       amplitude.logEvent('test', null, callback);
       assert.lengthOf(server.requests, 0);
-      assert.equal(counter, 1);
-      assert.equal(value, 0);
-      assert.equal(message, 'No request sent');
 
       // check that request is made after delay, but callback is not run a second time
       clock.tick(eventUploadPeriodMillis);
       assert.lengthOf(server.requests, 1);
       server.respondWith('success');
       server.respond();
+      assert.equal(value, 200);
+      assert.equal(message, 'success');
       assert.equal(counter, 1);
     });
 
@@ -1389,24 +1391,6 @@ describe('setVersionName', function() {
       assert.equal(counter, 1);
       assert.equal(value, 200);
       assert.equal(message, 'success');
-    });
-
-    it ('should run callback if server returns something other than 200 and 413', function () {
-      var counter = 0;
-      var value = -1;
-      var message = '';
-      var callback = function (status, response) {
-        counter++;
-        value = status;
-        message = response;
-      };
-
-      amplitude.logEvent('test', null, callback);
-      server.respondWith([404, {}, 'Not found']);
-      server.respond();
-      assert.equal(counter, 1);
-      assert.equal(value, 404);
-      assert.equal(message, 'Not found');
     });
 
     it('should send 3 identify events', function() {
@@ -1573,7 +1557,7 @@ describe('setVersionName', function() {
 
       amplitude.identify(new Identify().add('photoCount', 1));
       amplitude.logEvent('test');
-      delete amplitude.getInstance()._unsentEvents[0].sequence_number; // delete sequence number to simulate old event
+      delete amplitude.getInstance()._unsentEvents[0].event.sequence_number; // delete sequence number to simulate old event
       amplitude.getInstance()._sequenceNumber = 1; // reset sequence number
       amplitude.identify(new Identify().add('photoCount', 2));
 
@@ -1768,12 +1752,12 @@ describe('setVersionName', function() {
       });
     });
 
-    it('should validate user propeorties', function() {
+    it('should validate user properties', function() {
       var identify = new Identify().set(10, 10);
       amplitude.init(apiKey, null, {batchEvents: true});
       amplitude.identify(identify);
 
-      assert.deepEqual(amplitude.getInstance()._unsentIdentifys[0].user_properties, {'$set': {'10': 10}});
+      assert.deepEqual(amplitude.getInstance()._unsentIdentifys[0].event.user_properties, {'$set': {'10': 10}});
     });
 
     it('should synchronize event data across multiple amplitude instances that share the same cookie', function() {
@@ -1791,14 +1775,14 @@ describe('setVersionName', function() {
       amplitude1.logEvent('test5');
 
       // the event ids should all be sequential since amplitude1 and amplitude2 have synchronized cookies
-      var eventId = amplitude1.getInstance()._unsentEvents[0]['event_id'];
-      assert.equal(amplitude2.getInstance()._unsentEvents[0]['event_id'], eventId + 1);
-      assert.equal(amplitude1.getInstance()._unsentEvents[1]['event_id'], eventId + 2);
-      assert.equal(amplitude2.getInstance()._unsentEvents[1]['event_id'], eventId + 3);
+      var eventId = amplitude1.getInstance()._unsentEvents[0].event['event_id'];
+      assert.equal(amplitude2.getInstance()._unsentEvents[0].event['event_id'], eventId + 1);
+      assert.equal(amplitude1.getInstance()._unsentEvents[1].event['event_id'], eventId + 2);
+      assert.equal(amplitude2.getInstance()._unsentEvents[1].event['event_id'], eventId + 3);
 
-      var sequenceNumber = amplitude1.getInstance()._unsentEvents[0]['sequence_number'];
-      assert.equal(amplitude2.getInstance()._unsentIdentifys[0]['sequence_number'], sequenceNumber + 4);
-      assert.equal(amplitude1.getInstance()._unsentEvents[2]['sequence_number'], sequenceNumber +  5);
+      var sequenceNumber = amplitude1.getInstance()._unsentEvents[0].event['sequence_number'];
+      assert.equal(amplitude2.getInstance()._unsentIdentifys[0].event['sequence_number'], sequenceNumber + 4);
+      assert.equal(amplitude1.getInstance()._unsentEvents[2].event['sequence_number'], sequenceNumber +  5);
     });
 
     it('should handle groups input', function() {


### PR DESCRIPTION
The SDK would invoke the logEvent callback when an event was queued. This behavior is really confusing and looks like an error state to most people. Especially since it used status code 0. This confusing behavior makes people think their instrumentation is failing and sometimes it causes them to needlessly build event queues of their own just to send data to amplitude. 

With these changes, the callback is only invoked when an event is successfully sent or when the SDK gives up and decides it will never send an event.

The `_unsentEvent` and `_unsentIdentify` queues will now contain events with their callbacks `[{ event, callback }]`. Though when we serialize them to localStorage, we only serialize the events.