### PR TITLE
Pass the amplitude instance to onInit

### DIFF
--- a/src/amplitude-client.js
+++ b/src/amplitude-client.js
@@ -193,7 +193,7 @@ AmplitudeClient.prototype.init = function init(apiKey, opt_userId, opt_config, o
       this._sendEventsIfReady(); // try sending unsent events
 
       for (let i = 0; i < this._onInit.length; i++) {
-        this._onInit[i]();
+        this._onInit[i](this);
       }
       this._onInit = [];
       this._isInitialized = true;

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,10 @@
 /* jshint expr:true */
 import Amplitude from  './amplitude';
 
-var old = window.amplitude || {};
-var newInstance = new Amplitude();
+const old = window.amplitude || {};
+const newInstance = new Amplitude();
 newInstance._q = old._q || [];
-for (var instance in old._iq) { // migrate each instance's queue
+for (let instance in old._iq) { // migrate each instance's queue
   if (old._iq.hasOwnProperty(instance)) {
     newInstance.getInstance(instance)._q = old._iq[instance]._q || [];
   }

--- a/test/amplitude-client.js
+++ b/test/amplitude-client.js
@@ -64,24 +64,26 @@ describe('AmplitudeClient', function() {
       assert.equal(new AmplitudeClient('$DEFAULT_INSTANCE')._instanceName, '$default_instance');
     });
 
-    it('should invoke onInit callbacks', function() {
-      let onInitCalled = false;
-      let onInit2Called = false;
-      amplitude.onInit(() => { onInitCalled = true; });
-      amplitude.onInit(() => { onInit2Called = true; });
+    it('should invoke onInit callbacks', () => {
+      const callback = sinon.spy();
+      amplitude.onInit(callback);
+      amplitude.onInit(callback);
 
       amplitude.init(apiKey);
-      assert.ok(onInitCalled);
-      assert.ok(onInit2Called);
+      assert.isTrue(callback.calledTwice);
     });
 
-    it('should not invoke onInit callbacks before init is called', function() {
-      let onInitCalled = false;
-      amplitude.onInit(() => { onInitCalled = true; });
+    it('should not invoke onInit callbacks before init is called', () => {
+      const callback = sinon.spy();
+      amplitude.onInit(callback);
+      assert.isFalse(callback.calledOnce);
+    });
 
-      assert.ok(onInitCalled === false);
+    it('should pass the amplitude instance to onInit callbacks', () => {
+      const callback = sinon.spy();
+      amplitude.onInit(callback);
       amplitude.init(apiKey);
-      assert.ok(onInitCalled);
+      assert.isTrue(callback.calledWith(amplitude));
     });
 
     it('should set the Secure flag on cookie with the secureCookie option', () => {


### PR DESCRIPTION
This should make the callback passed to `onInit` actually useful.

The problem is the global window.amplitude is not assigned by the time amplitude invokes the onInit callbacks. I think in older versions of the SDK, it would just blindly assign itself to window.amplitude when it started up. This was a bit presumptuous as there are a lot of different ways of loading amplitude and the module loader ought to determine that.

Another alternative would be to have onInit calls happen in another tick. This is really hard to do well in a browser. Something like `setTimeout(() => onInit(), 0)` feels ugly and can sometimes take hundreds and hundreds of milliseconds to be called.

The solution here is to simply pass the amplitude instance that has been initialized as a parameter to the `onInit` function.