### PR TITLE
feat: add logAttributionCapturedEvent option

### DIFF
--- a/src/amplitude-client.js
+++ b/src/amplitude-client.js
@@ -355,7 +355,7 @@ AmplitudeClient.prototype._migrateUnsentEvents = function _migrateUnsentEvents(c
  */
 AmplitudeClient.prototype._trackParamsAndReferrer = function _trackParamsAndReferrer() {
   let utmProperties;
-  let referrerProperties
+  let referrerProperties;
   let gclidProperties;
   if (this.options.includeUtm) {
     utmProperties = this._initUtmData();

--- a/src/amplitude-client.js
+++ b/src/amplitude-client.js
@@ -354,14 +354,28 @@ AmplitudeClient.prototype._migrateUnsentEvents = function _migrateUnsentEvents(c
  * @private
  */
 AmplitudeClient.prototype._trackParamsAndReferrer = function _trackParamsAndReferrer() {
+  let utmProperties;
+  let referrerProperties
+  let gclidProperties;
   if (this.options.includeUtm) {
-    this._initUtmData();
+    utmProperties = this._initUtmData();
   }
   if (this.options.includeReferrer) {
-    this._saveReferrer(this._getReferrer());
+    referrerProperties = this._saveReferrer(this._getReferrer());
   }
   if (this.options.includeGclid) {
-    this._saveGclid(this._getUrlParams());
+    gclidProperties = this._saveGclid(this._getUrlParams());
+  }
+  if (this.options.logAttributionCapturedEvent) {
+    const attributionProperties = Object.assign(
+      {},
+      utmProperties,
+      referrerProperties,
+      gclidProperties
+    );
+    if (Object.keys(attributionProperties).length > 0) {
+      this.logEvent(Constants.ATTRIBUTION_EVENT, attributionProperties);
+    }
   }
 };
 
@@ -675,6 +689,7 @@ AmplitudeClient.prototype._initUtmData = function _initUtmData(queryParams, cook
   cookieParams = cookieParams || this.cookieStorage.get('__utmz');
   var utmProperties = getUtmData(cookieParams, queryParams);
   _sendParamsReferrerUserProperties(this, utmProperties);
+  return utmProperties;
 };
 
 /**
@@ -739,6 +754,7 @@ AmplitudeClient.prototype._saveGclid = function _saveGclid(urlParams) {
   }
   var gclidProperties = {'gclid': gclid};
   _sendParamsReferrerUserProperties(this, gclidProperties);
+  return gclidProperties;
 };
 
 /**
@@ -778,6 +794,7 @@ AmplitudeClient.prototype._saveReferrer = function _saveReferrer(referrer) {
     'referring_domain': this._getReferringDomain(referrer)
   };
   _sendParamsReferrerUserProperties(this, referrerInfo);
+  return referrerInfo;
 };
 
 /**

--- a/src/amplitude-client.js
+++ b/src/amplitude-client.js
@@ -367,12 +367,11 @@ AmplitudeClient.prototype._trackParamsAndReferrer = function _trackParamsAndRefe
     gclidProperties = this._saveGclid(this._getUrlParams());
   }
   if (this.options.logAttributionCapturedEvent) {
-    const attributionProperties = Object.assign(
-      {},
-      utmProperties,
-      referrerProperties,
-      gclidProperties
-    );
+    const attributionProperties = {
+      ...utmProperties,
+      ...referrerProperties,
+      ...gclidProperties,
+    };
     if (Object.keys(attributionProperties).length > 0) {
       this.logEvent(Constants.ATTRIBUTION_EVENT, attributionProperties);
     }

--- a/src/constants.js
+++ b/src/constants.js
@@ -39,5 +39,5 @@ export default {
   UTM_TERM: 'utm_term',
   UTM_CONTENT: 'utm_content',
 
-  ATTRIBUTION_EVENT: 'attribution captured'
+  ATTRIBUTION_EVENT: '$attributionCaptured'
 };

--- a/src/constants.js
+++ b/src/constants.js
@@ -39,5 +39,5 @@ export default {
   UTM_TERM: 'utm_term',
   UTM_CONTENT: 'utm_content',
 
-  ATTRIBUTION_EVENT: '$attributionCaptured'
+  ATTRIBUTION_EVENT: '[Amplitude] Attribution Captured'
 };

--- a/src/constants.js
+++ b/src/constants.js
@@ -37,5 +37,7 @@ export default {
   UTM_MEDIUM: 'utm_medium',
   UTM_CAMPAIGN: 'utm_campaign',
   UTM_TERM: 'utm_term',
-  UTM_CONTENT: 'utm_content'
+  UTM_CONTENT: 'utm_content',
+
+  ATTRIBUTION_EVENT: 'attribution captured'
 };

--- a/src/options.js
+++ b/src/options.js
@@ -30,6 +30,7 @@ export default {
   includeUtm: false,
   language: language.getLanguage(),
   logLevel: 'WARN',
+  logAttributionCapturedEvent: false,
   optOut: false,
   onError: () => {},
   platform,

--- a/test/browser/amplitudejs.html
+++ b/test/browser/amplitudejs.html
@@ -89,7 +89,7 @@
     }
 </script>
 <script>
-    amplitude.init('a2dbce0e18dfe5f8e74493843ff5c053', null, {includeReferrer: true, includeUtm: true, includeGclid: true, logAttributionCapturedEvent: true}, function() {
+    amplitude.init('a2dbce0e18dfe5f8e74493843ff5c053', null, {includeReferrer: true, includeUtm: true, includeGclid: true}, function() {
         alert(amplitude.options.deviceId);
     });
     amplitude.setVersionName('Web');

--- a/test/browser/amplitudejs.html
+++ b/test/browser/amplitudejs.html
@@ -89,7 +89,7 @@
     }
 </script>
 <script>
-    amplitude.init('a2dbce0e18dfe5f8e74493843ff5c053', null, {includeReferrer: true, includeUtm: true, includeGclid: true}, function() {
+    amplitude.init('a2dbce0e18dfe5f8e74493843ff5c053', null, {includeReferrer: true, includeUtm: true, includeGclid: true, logAttributionCapturedEvent: true}, function() {
         alert(amplitude.options.deviceId);
     });
     amplitude.setVersionName('Web');


### PR DESCRIPTION
## Description

This is related to a recent Growth Eng effort to audit and optimize our UTM tracking and attribution.  We would like a way to log an Amplitude event whenever attribution data is captured (utm, referrer, gclid).  This is to compare our Amplitude SDK attribution with our alternative UTMz tracking setup on the corpsite & blog (already added a similar event here: https://github.com/amplitude/amplitude.com/pull/133).

## [Jira Ticket](https://amplitude.atlassian.net/browse/GROWTH-1094)


# Why we need this
We want to be able to get a full picture of **every** UTM/attribution state that a user has had during their Journey with Amplitude.  Because Identify calls are not queryable, we are unable to devise a query that returns the information we are looking for.  Also, because attribution consists of many properties (utm_source, utm_medium, utm_campaign, etc.), not all of them will have values.

# Updated Context:
I met with @kelvin-lu last week to discuss this PR.  He suggested that it might be possibly to query using pre-existing events such as `pageview`.  I spent sometime investigating this approach and determined that it is not viable.  Even though pageview events have the attribution state present in user properties, they do not signify that attribution actually changed (which is what we are looking for).  Another idea I discussed with Kelvin was the ability to query identify events, but after speaking with Tanner, this approach has been explored and is impossible.  The only way for us to accurately fire this event is VIA the sdk.