### PR TITLE
Feature - introduce _collectParamsAndReferrer to allow accessing captured attribution data outside of SDK

### DIFF
--- a/src/amplitude-client.js
+++ b/src/amplitude-client.js
@@ -368,18 +368,23 @@ AmplitudeClient.prototype._trackParamsAndReferrer = function _trackParamsAndRefe
 };
 
 /**
- * Collect all utm, referral, and gclid data and combine into a single object
+ * Collect all utm, referral, and gclid data
  * @private
  */
-
 AmplitudeClient.prototype._getParamsAndReferrer = function _getParamsAndReferrer() {
-  const utmProperties = this.options.includeUtm ? this._getUtmProperties() : null;
-  const referrerProperties = this.options.includeReferrer
-    ? this._getReferrerProperties(this._getReferrer())
-    : null;
-  const gclidProperties = this.options.includeGlid
-    ? this._getGclidProperties(this._getUrlParams())
-    : null;
+  let utmProperties = null;
+  let referrerProperties = null;
+  let gclidProperties = null;
+
+  if (this.options.includeUtm) {
+    utmProperties = this._getUtmProperties()
+  }
+  if (this.options.includeReferrer) {
+    referrerProperties = this._getReferrerProperties(this._getReferrer())
+  }
+  if (this.options.includeGclid) {
+    gclidProperties = this._getGclidProperties(this._getUrlParams())
+  }
 
   return {
     utmProperties,
@@ -700,7 +705,7 @@ AmplitudeClient.prototype._getUtmProperties = function _getUtmProperties(queryPa
 };
 
 /**
- * Gets parsed utm properties and adds to user properties
+ * Accepts parsed utm properties and adds to user properties
  * @private
  */
 AmplitudeClient.prototype._initUtmData = function _initUtmData(utmProperties) {
@@ -759,7 +764,7 @@ AmplitudeClient.prototype._getUrlParams = function _getUrlParams() {
 };
 
 /**
- * Try to fetch Google Gclid from url params.
+ * Attempts to fetch Google Gclid from url params.
  * @private
  */
 AmplitudeClient.prototype._getGclidProperties = function _getGclidProperties(urlParams) {
@@ -771,7 +776,7 @@ AmplitudeClient.prototype._getGclidProperties = function _getGclidProperties(url
 };
 
 /**
- * Add Google Gclid as user properties
+ * Adds Google Gclid as user properties
  * @private
  */
 AmplitudeClient.prototype._saveGclid = function _saveGclid(gclidProperties) {
@@ -802,7 +807,7 @@ AmplitudeClient.prototype._getReferringDomain = function _getReferringDomain(ref
 };
 
 /**
- * Fetch the referrer information and the domain.
+ * Gets the referrer information and the domain.
  * @private
  */
 AmplitudeClient.prototype._getReferrerProperties = function _getReferrerProperties(referrer) {
@@ -816,7 +821,7 @@ AmplitudeClient.prototype._getReferrerProperties = function _getReferrerProperti
 };
 
 /**
- * Sends referrer properties
+ * Accepts parsed referrer properties and adds to user properties
  * Since user properties are propagated on the server, only send once per session, don't need to send with every event
  * @private
  */

--- a/src/amplitude-client.js
+++ b/src/amplitude-client.js
@@ -354,14 +354,16 @@ AmplitudeClient.prototype._migrateUnsentEvents = function _migrateUnsentEvents(c
  * @private
  */
 AmplitudeClient.prototype._trackParamsAndReferrer = function _trackParamsAndReferrer() {
+  const { utmProperties, referrerProperties, gclidProperties } = this._getParamsAndReferrer();
+
   if (this.options.includeUtm) {
-    this._initUtmData();
+    this._initUtmData(utmProperties);
   }
   if (this.options.includeReferrer) {
-    this._saveReferrer(this._getReferrer());
+    this._saveReferrer(referrerProperties);
   }
   if (this.options.includeGclid) {
-    this._saveGclid(this._getUrlParams());
+    this._saveGclid(gclidProperties);
   }
 };
 
@@ -371,18 +373,18 @@ AmplitudeClient.prototype._trackParamsAndReferrer = function _trackParamsAndRefe
  */
 
 AmplitudeClient.prototype._getParamsAndReferrer = function _getParamsAndReferrer() {
-  const utmProperties = this.options.includeUtm ? this._getUtmProperties() : {};
+  const utmProperties = this.options.includeUtm ? this._getUtmProperties() : null;
   const referrerProperties = this.options.includeReferrer
     ? this._getReferrerProperties(this._getReferrer())
-    : {};
+    : null;
   const gclidProperties = this.options.includeGlid
     ? this._getGclidProperties(this._getUrlParams())
-    : {};
+    : null;
 
   return {
-    ...utmProperties,
-    ...referrerProperties,
-    ...gclidProperties,
+    utmProperties,
+    referrerProperties,
+    gclidProperties,
   };
 };
 
@@ -701,8 +703,7 @@ AmplitudeClient.prototype._getUtmProperties = function _getUtmProperties(queryPa
  * Gets parsed utm properties and adds to user properties
  * @private
  */
-AmplitudeClient.prototype._initUtmData = function _initUtmData(queryParams, cookieParams) {
-  var utmProperties = this._getUtmProperties(queryParams, cookieParams);
+AmplitudeClient.prototype._initUtmData = function _initUtmData(utmProperties) {
   _sendParamsReferrerUserProperties(this, utmProperties);
 };
 
@@ -770,11 +771,10 @@ AmplitudeClient.prototype._getGclidProperties = function _getGclidProperties(url
 };
 
 /**
- * If Google Gclid exists, add as user properties
+ * Add Google Gclid as user properties
  * @private
  */
-AmplitudeClient.prototype._saveGclid = function _saveGclid(urlParams) {
-  var gclidProperties = this._getGclidProperties(urlParams);
+AmplitudeClient.prototype._saveGclid = function _saveGclid(gclidProperties) {
   _sendParamsReferrerUserProperties(this, gclidProperties);
 };
 
@@ -816,13 +816,12 @@ AmplitudeClient.prototype._getReferrerProperties = function _getReferrerProperti
 };
 
 /**
- * Check if referrer info exists and send.
+ * Sends referrer properties
  * Since user properties are propagated on the server, only send once per session, don't need to send with every event
  * @private
  */
-AmplitudeClient.prototype._saveReferrer = function _saveReferrer(referrer) {
-  var referrerInfo = this._getReferrerProperties(referrer);
-  _sendParamsReferrerUserProperties(this, referrerInfo);
+AmplitudeClient.prototype._saveReferrer = function _saveReferrer(referrerProperties) {
+  _sendParamsReferrerUserProperties(this, referrerProperties);
 };
 
 /**

--- a/src/amplitude-client.js
+++ b/src/amplitude-client.js
@@ -368,7 +368,7 @@ AmplitudeClient.prototype._trackParamsAndReferrer = function _trackParamsAndRefe
 };
 
 /**
- * Collect all utm, referral, and gclid data
+ * Fetch all utm, referral, and gclid data
  * @private
  */
 AmplitudeClient.prototype._getParamsAndReferrer = function _getParamsAndReferrer() {

--- a/src/amplitude-client.js
+++ b/src/amplitude-client.js
@@ -370,11 +370,15 @@ AmplitudeClient.prototype._trackParamsAndReferrer = function _trackParamsAndRefe
  * @private
  */
 
-AmplitudeClient.prototype._collectParamsAndReferrer = function _collectParamsAndReferrer() {
-  const utmProperties = this._getUtmProperties();
-  const referrerProperties = this._getReferrerProperties(this._getReferrer());
-  const gclidProperties = this._getGclidProperties(this._getUrlParams());
-  
+AmplitudeClient.prototype._getParamsAndReferrer = function _getParamsAndReferrer() {
+  const utmProperties = this.options.includeUtm ? this._getUtmProperties() : {};
+  const referrerProperties = this.options.includeReferrer
+    ? this._getReferrerProperties(this._getReferrer())
+    : {};
+  const gclidProperties = this.options.includeGlid
+    ? this._getGclidProperties(this._getUrlParams())
+    : {};
+
   return {
     ...utmProperties,
     ...referrerProperties,

--- a/src/amplitude-client.js
+++ b/src/amplitude-client.js
@@ -377,13 +377,13 @@ AmplitudeClient.prototype._getParamsAndReferrer = function _getParamsAndReferrer
   let gclidProperties = null;
 
   if (this.options.includeUtm) {
-    utmProperties = this._getUtmProperties()
+    utmProperties = this._getUtmProperties();
   }
   if (this.options.includeReferrer) {
-    referrerProperties = this._getReferrerProperties(this._getReferrer())
+    referrerProperties = this._getReferrerProperties(this._getReferrer());
   }
   if (this.options.includeGclid) {
-    gclidProperties = this._getGclidProperties(this._getUrlParams())
+    gclidProperties = this._getGclidProperties(this._getUrlParams());
   }
 
   return {

--- a/test/amplitude-client.js
+++ b/test/amplitude-client.js
@@ -2627,7 +2627,8 @@ describe('setVersionName', function() {
       cookie.set('__utmz', '133232535.1424926227.1.1.utmcct=top&utmccn=new');
       var utmParams = '?utm_source=amplitude&utm_medium=email&utm_term=terms';
       clock.tick(30 * 60 * 1000 + 1);
-      amplitude._initUtmData(utmParams);
+      var utmProperties = amplitude._getUtmProperties(utmParams);
+      amplitude._initUtmData(utmProperties);
 
       var expectedProperties = {
           utm_campaign: 'new',

--- a/test/amplitude-client.js
+++ b/test/amplitude-client.js
@@ -2626,8 +2626,8 @@ describe('setVersionName', function() {
       reset();
       cookie.set('__utmz', '133232535.1424926227.1.1.utmcct=top&utmccn=new');
       var utmParams = '?utm_source=amplitude&utm_medium=email&utm_term=terms';
-      clock.tick(30 * 60 * 1000 + 1);
       var utmProperties = amplitude._getUtmProperties(utmParams);
+      clock.tick(30 * 60 * 1000 + 1);
       amplitude._initUtmData(utmProperties);
 
       var expectedProperties = {

--- a/test/amplitude.js
+++ b/test/amplitude.js
@@ -1954,8 +1954,9 @@ describe('setVersionName', function() {
       reset();
       cookie.set('__utmz', '133232535.1424926227.1.1.utmcct=top&utmccn=new');
       var utmParams = '?utm_source=amplitude&utm_medium=email&utm_term=terms';
+      var utmProperties = amplitude.getInstance()._getUtmProperties(utmParams);
       clock.tick(30 * 60 * 1000 + 1);
-      amplitude.getInstance()._initUtmData(utmParams);
+      amplitude.getInstance()._initUtmData(utmProperties);
 
       var expectedProperties = {
           utm_campaign: 'new',

--- a/test/browser/amplitudejs.html
+++ b/test/browser/amplitudejs.html
@@ -27,7 +27,7 @@
                    'setOptOut', 'setVersionName', 'setDomain', 'setDeviceId',
                    'setGlobalUserProperties', 'identify', 'clearUserProperties',
                    'setGroup', 'logRevenueV2', 'regenerateDeviceId',
-                   'logEventWithTimestamp', 'logEventWithGroups'];
+                   'logEventWithTimestamp', 'logEventWithGroups', 'onInit'];
       function setUpProxy(instance) {
         function proxyMain(fn) {
           instance[fn] = function() {
@@ -89,6 +89,14 @@
     }
 </script>
 <script>
+    // Used to show proof of concept, will be removed before merging
+    amplitude.getInstance('app5').onInit((client) => {
+      const isNewSession = client.isNewSession();
+      if (isNewSession) {
+        const attributionProperties = client._collectParamsAndReferrer();
+        client.logEvent('attribution captured', attributionProperties);
+      }
+    });
     amplitude.init('a2dbce0e18dfe5f8e74493843ff5c053', null, {includeReferrer: true, includeUtm: true, includeGclid: true}, function() {
         alert(amplitude.options.deviceId);
     });
@@ -109,6 +117,10 @@
 
     amplitude.getInstance('app4').init('1d2fe1e104eb3f07a24e94d359f70fd5', 'joe@gmail.com');
     amplitude.getInstance('app4').logEvent('app 4 page load');
+
+    // Used to show proof of concept, will be removed
+    amplitude.getInstance('app5').logEvent('log event before init');
+    amplitude.getInstance('app5').init('1d2fe1e104eb3f07a24e94d359f70fd5', {includeReferrer: true, includeUtm: true, includeGclid: true});
 </script>
 <body>
 <h3>Amplitude JS Test</h3>

--- a/test/browser/amplitudejs.html
+++ b/test/browser/amplitudejs.html
@@ -89,14 +89,6 @@
     }
 </script>
 <script>
-    // Used to show proof of concept, will be removed before merging
-    amplitude.getInstance('app5').onInit((client) => {
-      const isNewSession = client.isNewSession();
-      if (isNewSession) {
-        const attributionProperties = client._collectParamsAndReferrer();
-        client.logEvent('attribution captured', attributionProperties);
-      }
-    });
     amplitude.init('a2dbce0e18dfe5f8e74493843ff5c053', null, {includeReferrer: true, includeUtm: true, includeGclid: true}, function() {
         alert(amplitude.options.deviceId);
     });
@@ -117,10 +109,6 @@
 
     amplitude.getInstance('app4').init('1d2fe1e104eb3f07a24e94d359f70fd5', 'joe@gmail.com');
     amplitude.getInstance('app4').logEvent('app 4 page load');
-
-    // Used to show proof of concept, will be removed
-    amplitude.getInstance('app5').logEvent('log event before init');
-    amplitude.getInstance('app5').init('1d2fe1e104eb3f07a24e94d359f70fd5', {includeReferrer: true, includeUtm: true, includeGclid: true});
 </script>
 <body>
 <h3>Amplitude JS Test</h3>


### PR DESCRIPTION
## Description

This PR introduces a refactor to `_trackParamsAndReferrer`.  It seperates the collecting of raw attribution values (utm, gclid, referrer) into pure functions, and then adds a new function `_collectParamsAndReferrer` that is almost identical to `_trackParamsAndReferrer` but just avoids making an additional identify call.  credit to @kelvin-lu for helping think of this.

Here is how I would use this in the product/corpsite:
```
    amplitude.getInstance().onInit((client) => {
      const isNewSession = client.isNewSession();
      if (isNewSession) {
        const attributionProperties = client._collectParamsAndReferrer();
        client.logEvent('attribution captured', attributionProperties);
      }
    });
```

This is related to a recent Growth Eng effort to audit and optimize our UTM tracking and attribution.  We would like a way to log an Amplitude event whenever attribution data is captured (utm, referrer, gclid).  This is to compare our Amplitude SDK attribution with our alternative UTMz tracking setup on the corpsite & blog (already added a similar event here: https://github.com/amplitude/amplitude.com/pull/133).  The SDK **does not need to be the one logging the event**, we just need access to the data.

## [Jira Ticket](https://amplitude.atlassian.net/browse/GROWTH-1094)
![image](https://user-images.githubusercontent.com/17172317/93401437-ffb20280-f836-11ea-8432-c158ee00c888.png)


# Why we need this
We want to be able to get a full picture of **every** UTM/attribution state that a user has had during their Journey with Amplitude.  Because Identify calls are not queryable, we are unable to devise a query that returns the information we are looking for.  Also, because attribution consists of many properties (utm_source, utm_medium, utm_campaign, etc.), not all of them will have values.  We do not require the SDK to send the event, we just need access to the data.

# Updated Context:
I met with @kelvin-lu last week to discuss this PR.  He suggested that it might be possibly to query using pre-existing events such as `pageview`.  I spent sometime investigating this approach and determined that it is not viable.  Even though pageview events have the attribution state present in user properties, they do not signal that attribution was actually captured at that exact point (which is what we are looking for).  Another idea I discussed with Kelvin was the ability to query identify events, but after speaking with Tanner, this approach has been explored and is impossible.  

# New solution
I proposed a solution in PR #295, but it is not ideal.  Until we fully determine that other users might like the auto attribution logging behavior, I believe this solution is a better alternative in the meantime. cc @haoliu-amp 