### PR TITLE
fix: Fall back to the other ways, if the device Id is not available from get queries #302

### DIFF
--- a/src/amplitude-client.js
+++ b/src/amplitude-client.js
@@ -283,7 +283,10 @@ AmplitudeClient.prototype._getInitialDeviceId = function (configDeviceId, stored
   }
 
   if (this.options.deviceIdFromUrlParam) {
-    return this._getDeviceIdFromUrlParam(this._getUrlParams());
+    let deviceIdFromUrlParam = this._getDeviceIdFromUrlParam(this._getUrlParams());
+    if(deviceIdFromUrlParam) {
+        return deviceIdFromUrlParam;
+    }
   }
 
   if (this.options.deviceId) {

--- a/src/amplitude-client.js
+++ b/src/amplitude-client.js
@@ -284,7 +284,7 @@ AmplitudeClient.prototype._getInitialDeviceId = function (configDeviceId, stored
 
   if (this.options.deviceIdFromUrlParam) {
     let deviceIdFromUrlParam = this._getDeviceIdFromUrlParam(this._getUrlParams());
-    if(deviceIdFromUrlParam) {
+    if (deviceIdFromUrlParam) {
         return deviceIdFromUrlParam;
     }
   }

--- a/test/amplitude-client.js
+++ b/test/amplitude-client.js
@@ -248,6 +248,20 @@ describe('AmplitudeClient', function() {
       amplitude._getUrlParams.restore();
     });
 
+    it ('should create device id if not set in the url', function(){
+        sinon.stub(amplitude, '_getUrlParams').returns('?utm_source=amplitude&utm_medium=email&gclid=12345');
+        amplitude.init(apiKey, userId, {deviceIdFromUrlParam: true});
+        assert.notEqual(amplitude.options.deviceId, null);
+        assert.lengthOf(amplitude.options.deviceId, 22);
+
+        const storage = new MetadataStorage({storageKey: cookieName});
+        const cookieData = storage.load();
+        assert.notEqual(cookieData.deviceId, null);
+        assert.lengthOf(cookieData.deviceId, 22);
+
+        amplitude._getUrlParams.restore();
+    });
+
     it ('should prefer the device id in the config over the url params', function() {
       var deviceId = 'dd_cc_bb_aa';
       sinon.stub(amplitude, '_getUrlParams').returns('?utm_source=amplitude&utm_medium=email&gclid=12345&amp_device_id=aa_bb_cc_dd');


### PR DESCRIPTION
### Make _getInitialDeviceId fall back to the other options/a base64Id, if the device Id is not available in the params via amp_device_id in case deviceIdFromUrlParam is true #302 

Fixes #302 

Please let me know, if there are any problems.

### Checklist

* [x] Does your PR title have the correct [title format](../CONTRIBUTING.md#pr-commit-title-conventions)
* [x] Does your PR have a breaking change? - No
