### PR TITLE
fix(cookies): reduce cookie lifetime

### DIFF
--- a/src/options.js
+++ b/src/options.js
@@ -14,7 +14,7 @@ if (BUILD_COMPAT_REACT_NATIVE) {
 export default {
   apiEndpoint: 'api.amplitude.com',
   batchEvents: false,
-  cookieExpiration: 365 * 10,
+  cookieExpiration: 365, // 12 months is for GDPR compliance
   cookieName: 'amplitude_id', // this is a deprecated option
   sameSiteCookie: 'Lax', // cookie privacy policy
   cookieForceUpgrade: false,
@@ -52,7 +52,7 @@ export default {
     os_version: true,
     platform: true,
     region: true,
-    version_name: true
+    version_name: true,
   },
   unsetParamsReferrerOnNewSession: false,
   unsentKey: 'amplitude_unsent',

--- a/test/amplitude-client.js
+++ b/test/amplitude-client.js
@@ -3297,7 +3297,7 @@ describe('setVersionName', function() {
   describe('setDomain', function() {
     beforeEach(() => {
       reset();
-      amplitude.init(apiKey, null, { cookieExpiration: 365, secureCookie: true });
+      amplitude.init(apiKey, null, { cookieExpiration: 1, secureCookie: true });
     });
 
     it('should set the cookie domain to null for an invalid domain', () => {
@@ -3309,7 +3309,7 @@ describe('setVersionName', function() {
     it('should not change the expirationDays options', () => {
       amplitude.setDomain('.foobar.com');
       const options = cookie.options();
-      assert.equal(options.expirationDays, 365);
+      assert.equal(options.expirationDays, 1);
     });
 
     it('should not change the secureCookie options', () => {

--- a/test/amplitude-client.js
+++ b/test/amplitude-client.js
@@ -166,7 +166,7 @@ describe('AmplitudeClient', function() {
       amplitude.init(apiKey, userId, config);
       assert.equal(amplitude.options.apiEndpoint, 'api.amplitude.com');
       assert.equal(amplitude.options.batchEvents, false);
-      assert.equal(amplitude.options.cookieExpiration, 3650);
+      assert.equal(amplitude.options.cookieExpiration, 365);
       assert.equal(amplitude.options.cookieName, 'amplitude_id');
       assert.equal(amplitude.options.eventUploadPeriodMillis, 30000);
       assert.equal(amplitude.options.eventUploadThreshold, 30);

--- a/test/amplitude.js
+++ b/test/amplitude.js
@@ -268,7 +268,7 @@ describe('Amplitude', function() {
       amplitude.init(apiKey, userId, config);
       assert.equal(amplitude.options.apiEndpoint, 'api.amplitude.com');
       assert.equal(amplitude.options.batchEvents, false);
-      assert.equal(amplitude.options.cookieExpiration, 3650);
+      assert.equal(amplitude.options.cookieExpiration, 365);
       assert.equal(amplitude.options.cookieName, 'amplitude_id');
       assert.equal(amplitude.options.eventUploadPeriodMillis, 30000);
       assert.equal(amplitude.options.eventUploadThreshold, 30);

--- a/test/cookie.js
+++ b/test/cookie.js
@@ -1,50 +1,47 @@
 import cookie from '../src/cookie.js';
-import baseCookie from '../src/base-cookie';
-import getLocation from '../src/get-location';
 
-describe('Cookie', function() {
-
-  before(function() {
+describe('Cookie', () => {
+  before(() => {
     cookie.reset();
   });
 
-  afterEach(function() {
+  afterEach(() => {
     cookie.remove('x');
     cookie.reset();
   });
 
-  describe('get', function() {
-    it('should get an existing cookie', function() {
-      cookie.set('x', { a : 'b' });
-      assert.deepEqual(cookie.get('x'), { a : 'b' });
+  describe('get', () => {
+    it('should get an existing cookie', () => {
+      cookie.set('x', { a: 'b' });
+      assert.deepEqual(cookie.get('x'), { a: 'b' });
     });
 
-    it('should not throw an error on a malformed cookie', function () {
-      document.cookie="x=y; path=/";
+    it('should not throw an error on a malformed cookie', () => {
+      document.cookie = 'x=y; path=/';
       assert.isNull(cookie.get('x'));
     });
   });
 
-  describe('remove', function () {
-    it('should remove a cookie', function() {
-      cookie.set('x', { a : 'b' });
-      assert.deepEqual(cookie.get('x'), { a : 'b' });
+  describe('remove', () => {
+    it('should remove a cookie', () => {
+      cookie.set('x', { a: 'b' });
+      assert.deepEqual(cookie.get('x'), { a: 'b' });
       cookie.remove('x');
       assert.isNull(cookie.get('x'));
     });
   });
 
-  describe('options', function() {
-    it('should set default options', function() {
+  describe('options', () => {
+    it('should set default options', () => {
       assert.deepEqual(cookie.options(), {
         expirationDays: undefined,
-        domain: undefined
+        domain: undefined,
       });
     });
 
-    it('should save options', function() {
-      cookie.options({ expirationDays: 365 });
-      assert.equal(cookie.options().expirationDays, 365);
+    it('should save options', () => {
+      cookie.options({ expirationDays: 1 });
+      assert.equal(cookie.options().expirationDays, 1);
     });
   });
 });


### PR DESCRIPTION
### Summary

Resolves issue #275 - reduce the cookie expiration to only 1 year to be GDPR compliant by default. 
### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-JavaScript/blob/master/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
