### PR TITLE
feat: make oninit public

### DIFF
--- a/src/amplitude-client.js
+++ b/src/amplitude-client.js
@@ -492,7 +492,7 @@ AmplitudeClient.prototype.isNewSession = function isNewSession() {
 
 /**
  * Store callbacks to call after init
- * @private
+ * @public
  */
 AmplitudeClient.prototype.onInit = function (callback) {
   if (this._isInitialized) {

--- a/src/amplitude-client.js
+++ b/src/amplitude-client.js
@@ -491,7 +491,7 @@ AmplitudeClient.prototype.isNewSession = function isNewSession() {
 };
 
 /**
- * Store callbacks to call after init
+ * Add callbacks to call after init. Useful for users who load Amplitude through a snippet.
  * @public
  */
 AmplitudeClient.prototype.onInit = function (callback) {


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude JavaScript SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

- Make `AmplitudeClient.onInit` public. It's [stubbed in the snippet](https://github.com/amplitude/Amplitude-JavaScript/blob/master/src/amplitude-snippet.js#L36), isn't used privately anywhere, and seems like it would be valuable for users who load through snippets.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-JavaScript/blob/master/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  NO
