### PR TITLE
ci: change ci bot author

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,12 @@ jobs:
     name: Release
     runs-on: ubuntu-18.04
     needs: [authorize]
+    env:
+      GIT_AUTHOR_NAME: amplitude-sdk-bot
+      GIT_AUTHOR_EMAIL: amplitude-sdk-bot@users.noreply.github.com
+      GIT_COMMITTER_NAME: amplitude-sdk-bot
+      GIT_COMMITTER_EMAIL: amplitude-sdk-bot@users.noreply.github.com
+
     steps:
       - name: Checkout
         uses: actions/checkout@v1


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude JavaScript SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Changes the semantic-release bot author from the default [semantic-release-bot](https://github.com/semantic-release-bot) to our own [amplitude-sdk bot](https://github.com/amplitude-sdk-bot). Example: 

![image](https://user-images.githubusercontent.com/15751908/95916618-d022e700-0d5d-11eb-9ffe-65eda22c402a.png)


### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-JavaScript/blob/master/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  NO
