### PR TITLE
fix(react-native): Change @react-native-community/async-storage to @r…

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ A JavaScript SDK for tracking events and revenue to [Amplitude](https://www.ampl
 This library now supports react-native. It has two dependencies on react-native modules you will have to install yourself:
 
 * [react-native-device-info](https://www.npmjs.com/package/react-native-device-info) Tested with version 3.1.4
-* [@react-native-community/async-storage](https://www.npmjs.com/package/@react-native-community/async-storage) Tested with version 1.6.2
+* [@react-native-async-storage/async-storage](https://www.npmjs.com/package/@react-native-async-storage/async-storage) Tested with version 1.6.2
 
 ## Node.js
 Please visit [Amplitude-Node](https://github.com/amplitude/Amplitude-Node) for our Node SDK.

--- a/src/amplitude-client.js
+++ b/src/amplitude-client.js
@@ -23,7 +23,7 @@ let Platform;
 let DeviceInfo;
 if (BUILD_COMPAT_REACT_NATIVE) {
   const reactNative = require('react-native');
-  AsyncStorage = require('@react-native-community/async-storage').default;
+  AsyncStorage = require('@react-native-async-storage/async-storage').default;
   Platform = reactNative.Platform;
   DeviceInfo = require('react-native-device-info');
 }


### PR DESCRIPTION
### Summary

@react-native-community/async-storage changed its organization to @react-native-async-storage and therefor does not get any updates anymore. This pr changes the package to the proper one.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-JavaScript/blob/master/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no(?) but after updating people would need to install the "new" package
