### PR TITLE
feat(identity): New API to interact with Device and User ID

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "main": "amplitude.umd.js",
   "react-native": "amplitude.native.js",
   "dependencies": {
+    "@amplitude/identity": "^1.0.4",
     "@amplitude/ua-parser-js": "0.7.24",
     "@amplitude/utils": "^1.0.5",
     "blueimp-md5": "^2.10.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "main": "amplitude.umd.js",
   "react-native": "amplitude.native.js",
   "dependencies": {
-    "@amplitude/identity": "^1.0.4",
+    "@amplitude/identity": "^1.1.0",
     "@amplitude/ua-parser-js": "0.7.24",
     "@amplitude/utils": "^1.0.5",
     "blueimp-md5": "^2.10.0",

--- a/src/amplitude-client.js
+++ b/src/amplitude-client.js
@@ -1,8 +1,10 @@
 // Core of SDK code
+import UAParser from '@amplitude/ua-parser-js'; // Identifying device and browser info (maybe move to backend?)
 import { isBrowserEnv, prototypeJsFix } from '@amplitude/utils';
+
 import Constants from './constants';
 import cookieStorage from './cookiestorage';
-import MetadataStorage from '../src/metadata-storage';
+import MetadataStorage from './metadata-storage';
 import getUtmData from './utm'; // Urchin Tracking Module
 import Identify from './identify';
 import localStorage from './localstorage';  // jshint ignore:line
@@ -10,7 +12,6 @@ import md5 from 'blueimp-md5';
 import Request from './xhr';
 import Revenue from './revenue';
 import type from './type';
-import UAParser from '@amplitude/ua-parser-js'; // Identifying device and browser info (maybe move to backend?)
 import utils from './utils';
 import UUID from './uuid';
 import base64Id from './base64Id';
@@ -83,7 +84,7 @@ AmplitudeClient.prototype.init = function init(apiKey, opt_userId, opt_config, o
 
   try {
     _parseConfig(this.options, opt_config);
-    
+
     if (isBrowserEnv() && window.Prototype !== undefined && Array.prototype.toJSON) {
       prototypeJsFix();
       utils.log.warn('Prototype.js injected Array.prototype.toJSON. Deleting Array.prototype.toJSON to prevent double-stringify');

--- a/src/amplitude-client.js
+++ b/src/amplitude-client.js
@@ -518,18 +518,18 @@ AmplitudeClient.prototype.onInit = function (callback) {
  * @public
  * @return {string} device ID of the current client.
  */
-Amplitude.prototype.getDeviceId = function getDeviceId() {
+AmplitudeClient.prototype.getDeviceId = function getDeviceId() {
   return identityManager.getInstance(this._instanceName).getDeviceId();
-}
+};
 
 /**
  * Returns the user ID attached to this amplitude client.
  * @public
  * @return {string | null} user ID of the current client.
  */
-Amplitude.prototype.getDeviceId = function getUserId() {
+AmplitudeClient.prototype.getDeviceId = function getUserId() {
   return identityManager.getInstance(this._instanceName).getUserId();
-}
+};
 
 
 /**
@@ -901,7 +901,7 @@ AmplitudeClient.prototype.setUserId = function setUserId(userId) {
 
   try {
     const safeUserId = (userId !== undefined && userId !== null && ('' + userId)) || null;
-    identityManager.getInstance(this._instanceName).setUserId(safeUserId)
+    identityManager.getInstance(this._instanceName).setUserId(safeUserId);
     _saveCookieData(this);
   } catch (e) {
     utils.log.error(e);
@@ -1044,7 +1044,7 @@ AmplitudeClient.prototype.resetIdentity = function resetIdentity(deviceId, userI
   identityManager.resetInstance(this._instanceName, newIdentity);
   // Save the new info to metadata
   _saveCookieData(this);
-}
+};
 
 /**
  * Sets user properties for the current user.

--- a/src/amplitude-snippet.js
+++ b/src/amplitude-snippet.js
@@ -31,8 +31,8 @@
   for (var j = 0; j < revenueFuncs.length; j++) {proxy(Revenue, revenueFuncs[j]);}
   amplitude.Revenue = Revenue;
   var funcs = ['init', 'logEvent', 'logRevenue', 'setUserId', 'setUserProperties',
-               'setOptOut', 'setVersionName', 'setDomain', 'setDeviceId', 'enableTracking',
-               'setGlobalUserProperties', 'identify', 'clearUserProperties',
+               'setOptOut', 'setVersionName', 'setDomain', 'setDeviceId', 'getDeviceId', 'getUserId',
+                'enableTracking', 'setGlobalUserProperties', 'identify', 'clearUserProperties',
                'setGroup', 'logRevenueV2', 'regenerateDeviceId', 'groupIdentify', 'onInit',
                'logEventWithTimestamp', 'logEventWithGroups', 'setSessionId', 'resetSessionId'];
   function setUpProxy(instance) {

--- a/src/amplitude.js
+++ b/src/amplitude.js
@@ -9,10 +9,10 @@ import DEFAULT_OPTIONS from './options';
 
 /**
  * Deprecated legacy API of the Amplitude JS SDK - instance manager.
- * 
+ *
  * Wraps around the current [AmplitudeClient](https://amplitude.github.io/Amplitude-JavaScript/) which provides more features
  * Function calls directly on amplitude have been deprecated. Please call methods on the default shared instance: amplitude.getInstance() instead.
- * 
+ *
  * See the [3.0.0 changelog](https://github.com/amplitude/Amplitude-JavaScript/blob/ed405afb5f06d5cf5b72539a5d09179abcf7e1fe/README.md#300-update-and-logging-events-to-multiple-amplitude-apps) for more information about this change.
  * @constructor Amplitude
  * @public
@@ -204,7 +204,7 @@ if (BUILD_COMPAT_2_0) {
   /**
     * Sets a custom deviceId for current user. Note: this is not recommended unless you know what you are doing
     * (like if you have your own system for managing deviceIds).
-    * 
+    *
     * Make sure the deviceId you set is sufficiently unique
     * (we recommend something like a UUID - see src/uuid.js for an example of how to generate) to prevent conflicts with other devices in our system.
     * @public
@@ -290,10 +290,10 @@ if (BUILD_COMPAT_2_0) {
 
   /**
    * Log an event with eventType, eventProperties, and groups. Use this to set event-level groups.
-   * 
+   *
    * Note: the group(s) set only apply for the specific event type being logged and does not persist on the user
    * (unless you explicitly set it with setGroup).
-   * 
+   *
    * See the [advanced topics article](https://developers.amplitude.com/docs/setting-user-groups) for more information.
    * about groups and Count by Distinct on the Amplitude platform.
    * @public
@@ -313,7 +313,7 @@ if (BUILD_COMPAT_2_0) {
   /**
    * Log revenue with Revenue interface. The new revenue interface allows for more revenue fields like
    * revenueType and event properties.
-   * 
+   *
    * See the [Revenue](https://amplitude.github.io/Amplitude-JavaScript/Revenue/)
    * reference page for more information on the Revenue interface and logging revenue.
    * @public

--- a/test/amplitude-client.js
+++ b/test/amplitude-client.js
@@ -133,23 +133,23 @@ describe('AmplitudeClient', function() {
 
       amplitude.init(apiKey);
       assert.equal(amplitude.options.apiKey, apiKey);
-      assert.lengthOf(amplitude.getDeviceId(), 22);
+      assert.lengthOf(amplitude.getDeviceId(), 25);
     });
 
     it('should accept userId', function() {
       amplitude.init(apiKey, userId);
-      assert.equal(amplitude.options.userId, userId);
+      assert.equal(amplitude.getUserId(), userId);
     });
 
     it('should accept numerical userIds', function() {
       const userId = 5;
       amplitude.init(apiKey, 5);
-      assert.equal(amplitude.options.userId, '5');
+      assert.equal(amplitude.getUserId(), '5');
     });
 
     it('should generate a random deviceId', function() {
       amplitude.init(apiKey, userId);
-      assert.lengthOf(amplitude.getDeviceId(), 22)
+      assert.lengthOf(amplitude.getDeviceId(), 25)
     });
 
     it('should validate config values', function() {
@@ -195,7 +195,7 @@ describe('AmplitudeClient', function() {
       const stored = storage.load();
       assert.property(stored, 'deviceId');
       assert.propertyVal(stored, 'userId', userId);
-      assert.lengthOf(stored.deviceId, 22);
+      assert.lengthOf(stored.deviceId, 25);
     });
 
     it('should set language', function() {
@@ -252,12 +252,12 @@ describe('AmplitudeClient', function() {
         sinon.stub(amplitude, '_getUrlParams').returns('?utm_source=amplitude&utm_medium=email&gclid=12345');
         amplitude.init(apiKey, userId, {deviceIdFromUrlParam: true});
         assert.notEqual(amplitude.getDeviceId(), null);
-        assert.lengthOf(amplitude.getDeviceId(), 22);
+        assert.lengthOf(amplitude.getDeviceId(), 25);
 
         const storage = new MetadataStorage({storageKey: cookieName});
         const cookieData = storage.load();
         assert.notEqual(cookieData.deviceId, null);
-        assert.lengthOf(cookieData.deviceId, 22);
+        assert.lengthOf(cookieData.deviceId, 25);
 
         amplitude._getUrlParams.restore();
     });
@@ -783,7 +783,7 @@ it ('should load saved events from localStorage new keys and send events', funct
       assert.lengthOf(amplitude._q, 2);
       amplitude.runQueuedFunctions();
 
-      assert.equal(amplitude.options.userId, userId);
+      assert.equal(amplitude.getUserId(), userId);
       assert.equal(amplitude._unsentCount(), 1);
       assert.lengthOf(server.requests, 1);
       var events = JSON.parse(queryString.parse(server.requests[0].requestBody).e);
@@ -934,7 +934,7 @@ describe('setVersionName', function() {
       amplitude.init(apiKey, null, {'deviceId': deviceId});
       amplitude.regenerateDeviceId();
       assert.notEqual(amplitude.getDeviceId(), deviceId);
-      assert.lengthOf(amplitude.getDeviceId(), 22);
+      assert.lengthOf(amplitude.getDeviceId(), 25);
     });
   });
 

--- a/test/amplitude-client.js
+++ b/test/amplitude-client.js
@@ -125,15 +125,15 @@ describe('AmplitudeClient', function() {
     it('fails on invalid apiKeys', function() {
       amplitude.init(null);
       assert.equal(amplitude.options.apiKey, undefined);
-      assert.equal(amplitude.options.deviceId, undefined);
+      assert.equal(amplitude.getDeviceId(), undefined);
 
       amplitude.init('');
       assert.equal(amplitude.options.apiKey, undefined);
-      assert.equal(amplitude.options.deviceId, undefined);
+      assert.equal(amplitude.getDeviceId(), undefined);
 
       amplitude.init(apiKey);
       assert.equal(amplitude.options.apiKey, apiKey);
-      assert.lengthOf(amplitude.options.deviceId, 22);
+      assert.lengthOf(amplitude.getDeviceId(), 22);
     });
 
     it('should accept userId', function() {
@@ -149,7 +149,7 @@ describe('AmplitudeClient', function() {
 
     it('should generate a random deviceId', function() {
       amplitude.init(apiKey, userId);
-      assert.lengthOf(amplitude.options.deviceId, 22)
+      assert.lengthOf(amplitude.getDeviceId(), 22)
     });
 
     it('should validate config values', function() {
@@ -226,7 +226,7 @@ describe('AmplitudeClient', function() {
       var deviceId = 'aa_bb_cc_dd';
       sinon.stub(amplitude, '_getUrlParams').returns('?utm_source=amplitude&utm_medium=email&gclid=12345&amp_device_id=aa_bb_cc_dd');
       amplitude.init(apiKey, userId, {deviceIdFromUrlParam: true});
-      assert.equal(amplitude.options.deviceId, deviceId);
+      assert.equal(amplitude.getDeviceId(), deviceId);
 
       const storage = new MetadataStorage({storageKey: cookieName});
       const cookieData = storage.load();
@@ -239,7 +239,7 @@ describe('AmplitudeClient', function() {
       var deviceId = 'aa_bb_cc_dd';
       sinon.stub(amplitude, '_getUrlParams').returns('?utm_source=amplitude&utm_medium=email&gclid=12345&amp_device_id=aa_bb_cc_dd');
       amplitude.init(apiKey, userId, {deviceIdFromUrlParam: false});
-      assert.notEqual(amplitude.options.deviceId, deviceId);
+      assert.notEqual(amplitude.getDeviceId(), deviceId);
 
       const storage = new MetadataStorage({storageKey: cookieName});
       const cookieData = storage.load();
@@ -251,8 +251,8 @@ describe('AmplitudeClient', function() {
     it ('should create device id if not set in the url', function(){
         sinon.stub(amplitude, '_getUrlParams').returns('?utm_source=amplitude&utm_medium=email&gclid=12345');
         amplitude.init(apiKey, userId, {deviceIdFromUrlParam: true});
-        assert.notEqual(amplitude.options.deviceId, null);
-        assert.lengthOf(amplitude.options.deviceId, 22);
+        assert.notEqual(amplitude.getDeviceId(), null);
+        assert.lengthOf(amplitude.getDeviceId(), 22);
 
         const storage = new MetadataStorage({storageKey: cookieName});
         const cookieData = storage.load();
@@ -266,7 +266,7 @@ describe('AmplitudeClient', function() {
       var deviceId = 'dd_cc_bb_aa';
       sinon.stub(amplitude, '_getUrlParams').returns('?utm_source=amplitude&utm_medium=email&gclid=12345&amp_device_id=aa_bb_cc_dd');
       amplitude.init(apiKey, userId, {deviceId: deviceId, deviceIdFromUrlParam: true});
-      assert.equal(amplitude.options.deviceId, deviceId);
+      assert.equal(amplitude.getDeviceId(), deviceId);
 
       const storage = new MetadataStorage({storageKey: cookieName});
       const cookieData = storage.load();
@@ -286,7 +286,7 @@ describe('AmplitudeClient', function() {
       cookie.set(amplitude.options.cookieName + '_' + apiKey, cookieData);
 
       amplitude.init(apiKey);
-      assert.equal(amplitude.options.deviceId, 'current_device_id');
+      assert.equal(amplitude.getDeviceId(), 'current_device_id');
     });
 
     it('should upgrade the new cookie to the old cookie if forceUpgrade is on', function(){
@@ -342,7 +342,7 @@ describe('AmplitudeClient', function() {
       cookie.set(oldCookieName, cookieData);
 
       amplitude.init(apiKey, null);
-      assert.equal(amplitude.options.deviceId, 'old_device_id');
+      assert.equal(amplitude.getDeviceId(), 'old_device_id');
     });
 
     it('should favor the device id from the new cookie even if the old cookie exists', function(){
@@ -361,7 +361,7 @@ describe('AmplitudeClient', function() {
       cookie.setRaw(cookieName, `new_device_id.${Base64.encode(userId)}..1000.1000.0.0.0`);
 
       amplitude.init(apiKey, null);
-      assert.equal(amplitude.options.deviceId, 'new_device_id');
+      assert.equal(amplitude.getDeviceId(), 'new_device_id');
     });
 
     it('should save cookie data to localStorage if cookies are not enabled', function() {
@@ -933,8 +933,8 @@ describe('setVersionName', function() {
       var deviceId = 'oldDeviceId';
       amplitude.init(apiKey, null, {'deviceId': deviceId});
       amplitude.regenerateDeviceId();
-      assert.notEqual(amplitude.options.deviceId, deviceId);
-      assert.lengthOf(amplitude.options.deviceId, 22);
+      assert.notEqual(amplitude.getDeviceId(), deviceId);
+      assert.lengthOf(amplitude.getDeviceId(), 22);
     });
   });
 
@@ -951,21 +951,21 @@ describe('setVersionName', function() {
     it('should change device id', function() {
       amplitude.init(apiKey, null, {'deviceId': 'fakeDeviceId'});
       amplitude.setDeviceId('deviceId');
-      assert.equal(amplitude.options.deviceId, 'deviceId');
+      assert.equal(amplitude.getDeviceId(), 'deviceId');
     });
 
     it('should not change device id if empty', function() {
       amplitude.init(apiKey, null, {'deviceId': 'deviceId'});
       amplitude.setDeviceId('');
-      assert.notEqual(amplitude.options.deviceId, '');
-      assert.equal(amplitude.options.deviceId, 'deviceId');
+      assert.notEqual(amplitude.getDeviceId(), '');
+      assert.equal(amplitude.getDeviceId(), 'deviceId');
     });
 
     it('should not change device id if null', function() {
       amplitude.init(apiKey, null, {'deviceId': 'deviceId'});
       amplitude.setDeviceId(null);
-      assert.notEqual(amplitude.options.deviceId, null);
-      assert.equal(amplitude.options.deviceId, 'deviceId');
+      assert.notEqual(amplitude.getDeviceId(), null);
+      assert.equal(amplitude.getDeviceId(), 'deviceId');
     });
 
     it('should store device id in cookie', function() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,30 +2,53 @@
 # yarn lockfile v1
 
 
-"@amplitude/identity@^1.0.4":
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/@amplitude/identity/-/identity-1.0.4.tgz#9708e751b7add15369afd4ab6784dc26013aabe6"
-  integrity sha512-JG63rS7/UQOJPExXhddZ1y+JDioQNSg+lobhodjKTrMCbe+c1Ue9kjkZZSYzVZ4BeOCAg8Ai5AmfLm/PHRC9Kg==
+"@amplitude/eslint-config-typescript@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@amplitude/eslint-config-typescript/-/eslint-config-typescript-1.1.0.tgz#f6d876febda6f4470564e806576e43750d60a094"
+  integrity sha512-N8sKkwtFakPD2/cSOrBnM5Wudjp4qeDD69U1cG7dZ6DDczxBhUEqnJDJ0wiYmKMPXqr+bmFOsDdbCcOmb/CLYA==
+
+"@amplitude/identity@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@amplitude/identity/-/identity-1.1.0.tgz#e3023c01f94765bf10e3363b0be497472415be64"
+  integrity sha512-XaQL4tZwiYUJhSP/+R0MitgmiRzy8e8tbIzddOWcw2byiZjKed5DDB2TjYirBlLCqqlbt2bZKldG7W9tiSaLKw==
   dependencies:
-    "@amplitude/types" "^1.0.4"
-    "@amplitude/utils" "^1.0.4"
+    "@amplitude/eslint-config-typescript" "^1.1.0"
+    "@amplitude/types" "^1.1.0"
+    "@amplitude/utils" "^1.1.0"
+    tslib "^1.9.3"
 
 "@amplitude/types@^1.0.4":
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/@amplitude/types/-/types-1.0.4.tgz#21275b030c8267f9ea133a79c5c525e30c706d69"
   integrity sha512-iWdgTXiE0T/QCK88g2ezJEhJpYHDvDs0StVVPu1ygcl6qYzk/8xrNvbeEibiIBT8t/GJ8FtH5ZIPx3c4CMjlig==
 
+"@amplitude/types@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@amplitude/types/-/types-1.1.0.tgz#d9caf5f95d74e02e129c7b090deccd76be350b00"
+  integrity sha512-aJebJlI1hfRrzsbcRzW1heTDEClhElwEJ4ODyYZbBacKzH29q3OKZCkgNfaEYdxfgLpoDSh/ffHYpl7fWm3SQA==
+  dependencies:
+    "@amplitude/eslint-config-typescript" "^1.1.0"
+
 "@amplitude/ua-parser-js@0.7.24":
   version "0.7.24"
   resolved "https://registry.yarnpkg.com/@amplitude/ua-parser-js/-/ua-parser-js-0.7.24.tgz#2ce605af7d2c38d4a01313fb2385df55fbbd69aa"
   integrity sha512-VbQuJymJ20WEw0HtI2np7EdC3NJGUWi8+Xdbc7uk8WfMIF308T0howpzkQ3JFMN7ejnrcSM/OyNGveeE3TP3TA==
 
-"@amplitude/utils@^1.0.4", "@amplitude/utils@^1.0.5":
+"@amplitude/utils@^1.0.5":
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/@amplitude/utils/-/utils-1.0.5.tgz#843d96b7965c69213bb1896980bed2c1569fbbed"
   integrity sha512-leo4meeTAvp4W+UWk7EcWaJKuuJ3HqbNglRJPVAUYXaoCs2UzCnCVvjj5rUBN+Mhe0pAmkpEHHaS/1iv2prcKA==
   dependencies:
     "@amplitude/types" "^1.0.4"
+
+"@amplitude/utils@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@amplitude/utils/-/utils-1.1.0.tgz#987e539ec001412960239efc2a39029f655d0e8c"
+  integrity sha512-TbKgBZNSRFu5RfYTKpprn/DFlZqr8jnmjXASZyQ/m8XDdbD2VoRqHDmKUwFiruX9OhAb2m9BhjLuaiwRYHCcqQ==
+  dependencies:
+    "@amplitude/eslint-config-typescript" "^1.1.0"
+    "@amplitude/types" "^1.1.0"
+    tslib "^1.9.3"
 
 "@babel/code-frame@^7.0.0":
   version "7.0.0"
@@ -7872,6 +7895,11 @@ trim-right@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
   integrity sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=
+
+tslib@^1.9.3:
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
+  integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
 tunnel-agent@^0.6.0:
   version "0.6.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,14 @@
 # yarn lockfile v1
 
 
+"@amplitude/identity@^1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@amplitude/identity/-/identity-1.0.4.tgz#9708e751b7add15369afd4ab6784dc26013aabe6"
+  integrity sha512-JG63rS7/UQOJPExXhddZ1y+JDioQNSg+lobhodjKTrMCbe+c1Ue9kjkZZSYzVZ4BeOCAg8Ai5AmfLm/PHRC9Kg==
+  dependencies:
+    "@amplitude/types" "^1.0.4"
+    "@amplitude/utils" "^1.0.4"
+
 "@amplitude/types@^1.0.4":
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/@amplitude/types/-/types-1.0.4.tgz#21275b030c8267f9ea133a79c5c525e30c706d69"
@@ -12,7 +20,7 @@
   resolved "https://registry.yarnpkg.com/@amplitude/ua-parser-js/-/ua-parser-js-0.7.24.tgz#2ce605af7d2c38d4a01313fb2385df55fbbd69aa"
   integrity sha512-VbQuJymJ20WEw0HtI2np7EdC3NJGUWi8+Xdbc7uk8WfMIF308T0howpzkQ3JFMN7ejnrcSM/OyNGveeE3TP3TA==
 
-"@amplitude/utils@^1.0.5":
+"@amplitude/utils@^1.0.4", "@amplitude/utils@^1.0.5":
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/@amplitude/utils/-/utils-1.0.5.tgz#843d96b7965c69213bb1896980bed2c1569fbbed"
   integrity sha512-leo4meeTAvp4W+UWk7EcWaJKuuJ3HqbNglRJPVAUYXaoCs2UzCnCVvjj5rUBN+Mhe0pAmkpEHHaS/1iv2prcKA==


### PR DESCRIPTION
### Summary

Adds several new API's to have the JS SDK work with the Identity manager so that this data can be shared with skylab.
- Adds `getDeviceId()` and `getUserId()` instead of pulling from `this.options`
  - Rework tests to consume these functions
  - Rework other pieces of the amplitude client to also use these
- Deprecates `setDeviceId()`
  - Adds `resetIdentity()` as a replacement for `setDeviceId()` to be clearer on what should be happening
- Reworks `setUserId()` and `loadCookieProps` to use the identity manager
- Sorts the imports in `amplitude-client`

### BREAKING CHANGES

- `this.options` will no longer keep the most up-to-date device and user ID. We can change it so that it does but I feel like this means maintaining effectively two getter in the future


### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-JavaScript/blob/master/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  Yes
