### PR TITLE
fix(validation): Be able to take in and validate null object event/user properties

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -69,7 +69,7 @@ var truncate = function truncate(value) {
     }
   } else if (type(value) === 'object') {
     for (var key in value) {
-      if (value.hasOwnProperty(key)) {
+      if (key in value) {
         value[key] = truncate(value[key]);
       }
     }
@@ -110,7 +110,7 @@ var validateProperties = function validateProperties(properties) {
 
   var copy = {}; // create a copy with all of the valid properties
   for (var property in properties) {
-    if (!properties.hasOwnProperty(property)) {
+    if (!(property in properties)) {
       continue;
     }
 

--- a/test/utils.js
+++ b/test/utils.js
@@ -239,5 +239,19 @@ describe('utils', function() {
       }
       assert.deepEqual(utils.validateProperties(properties), {});
     });
+
+    it('should validate properties on null objects', function() {
+      var properties = Object.create(null);
+      properties['test'] = 'yes';
+      properties['key'] = 'value';
+      properties['15'] = '16';
+
+      var expected = {
+        'test': 'yes',
+        'key': 'value',
+        '15': '16'
+      };
+      assert.deepEqual(utils.validateProperties(properties), expected);
+    });
   });
 });


### PR DESCRIPTION
### Summary

Fixes #311 by using syntax that is allowed for null objects created by `Object.create(null)` (map-likes)
Should we be using it when creating jsons? Maybe.

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-JavaScript/blob/master/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
