### PR TITLE
feat(privacy): Add a `storage` option

### DIFF
--- a/src/amplitude-client.js
+++ b/src/amplitude-client.js
@@ -116,7 +116,8 @@ AmplitudeClient.prototype.init = function init(apiKey, opt_userId, opt_config, o
       expirationDays: this.options.cookieExpiration,
       domain: this.options.domain,
       secure: this.options.secureCookie,
-      sameSite: this.options.sameSiteCookie
+      sameSite: this.options.sameSiteCookie,
+      storage: this.options.storage
     });
 
     const hasOldCookie = !!this.cookieStorage.get(this._oldCookiename);

--- a/src/constants.js
+++ b/src/constants.js
@@ -21,6 +21,13 @@ export default {
   COOKIE_TEST_PREFIX: 'amp_cookie_test',
   COOKIE_PREFIX: "amp",
 
+  // Storage options
+  STORAGE_DEFAULT: '',
+  STORAGE_COOKIES: 'cookies',
+  STORAGE_NONE: 'none',
+  STORAGE_LOCAL: 'localStorage',
+  STORAGE_SESSION: 'sessionStorage',
+
   // revenue keys
   REVENUE_EVENT: 'revenue_amount',
   REVENUE_PRODUCT_ID: '$productId',

--- a/src/options.js
+++ b/src/options.js
@@ -1,3 +1,4 @@
+import Constants from './constants';
 import language from './language';
 
 let platform = 'Web';
@@ -19,7 +20,7 @@ export default {
   sameSiteCookie: 'Lax', // cookie privacy policy
   cookieForceUpgrade: false,
   deferInitialization: false,
-  disableCookies: false,
+  disableCookies: false, // this is a deprecated option
   deviceIdFromUrlParam: false,
   domain: '',
   eventUploadPeriodMillis: 30 * 1000, // 30s
@@ -39,6 +40,7 @@ export default {
   saveParamsReferrerOncePerSession: true,
   secureCookie: false,
   sessionTimeout: 30 * 60 * 1000,
+  storage: Constants.STORAGE_DEFAULT,
   trackingOptions: {
     city: true,
     country: true,

--- a/test/amplitude-client.js
+++ b/test/amplitude-client.js
@@ -304,8 +304,8 @@ describe('AmplitudeClient', function() {
       cookie.set(oldCookieName, cookieData);
 
       amplitude.init(apiKey, null, { cookieForceUpgrade: true });
-      const cookieData = cookie.getRaw(cookieName);
-      assert.equal('old_device_id', cookieData.slice(0, 'old_device_id'.length));
+      const cookieRawData = cookie.getRaw(cookieName);
+      assert.equal('old_device_id', cookieRawData.slice(0, 'old_device_id'.length));
     });
 
     it('should delete the old old cookie if forceUpgrade is on', function(){
@@ -323,8 +323,8 @@ describe('AmplitudeClient', function() {
       cookie.set(oldCookieName, cookieData);
 
       amplitude.init(apiKey, null, { cookieForceUpgrade: true });
-      const cookieData = cookie.get(oldCookieName);
-      assert.isNull(cookieData);
+      const cookieRawData = cookie.get(oldCookieName);
+      assert.isNull(cookieRawData);
     });
 
     it('should use device id from the old cookie if a new cookie does not exist', function(){

--- a/test/amplitude-client.js
+++ b/test/amplitude-client.js
@@ -24,13 +24,16 @@ describe('AmplitudeClient', function() {
   var userId = 'user';
   var amplitude;
   var server;
+  var sandbox
 
   beforeEach(function() {
     amplitude = new AmplitudeClient();
     server = sinon.fakeServer.create();
+    sandbox = sinon.sandbox.create();
   });
 
   afterEach(function() {
+    sandbox.restore();
     server.restore();
   });
 
@@ -445,6 +448,39 @@ describe('AmplitudeClient', function() {
       assert.equal(amplitude2._eventId, 50);
       assert.equal(amplitude2._identifyId, 60);
       assert.equal(amplitude2._sequenceNumber, 70);
+    });
+
+    it('should not persist anything if storage options is none', function() {
+      const clock = sandbox.useFakeTimers();
+      clock.tick(1000);
+
+      const amplitude2 = new AmplitudeClient();
+      amplitude2.init(apiKey, null, {storage: 'none'});
+      clock.tick(10);
+
+      const amplitude3 = new AmplitudeClient();
+      amplitude3.init(apiKey, null, {storage: 'none'});
+
+      assert.notEqual(amplitude2._sessionId, amplitude3._sessionId);
+    });
+
+    it('should load sessionId if storage options is sessionStorage', function() {
+      const clock = sandbox.useFakeTimers();
+      clock.tick(1000);
+      // Disable cookies read.
+      sandbox.stub(baseCookie, 'get').returns(null);
+
+      const amplitude2 = new AmplitudeClient();
+      amplitude2.init(apiKey, null, {storage: 'sessionStorage'});
+      clock.tick(10);
+
+      // Clear local storage to make sure it's not used.
+      localStorage.clear();
+
+      const amplitude3 = new AmplitudeClient();
+      amplitude3.init(apiKey, null, {storage: 'sessionStorage'});
+
+      assert.equal(amplitude2._sessionId, amplitude3._sessionId);
     });
 
     it('should load saved events from localStorage for default instance', function() {


### PR DESCRIPTION
# Summary

As discussed in #317, this PR creates a new option `storage` to be able to use `sessionStorage` for persisting the amplitude IDs with the session storage or even `none`to not persist anything. These are options are useful for privacy as callers of the Amplitude lib can now limit the persistant footprints on users' browsers.

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-JavaScript/blob/master/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?: no