### PR TITLE
fix: logEvent callback on content block

### DIFF
--- a/src/amplitude-client.js
+++ b/src/amplitude-client.js
@@ -1281,9 +1281,6 @@ AmplitudeClient.prototype._logEvent = function _logEvent(eventType, eventPropert
     return eventId;
   } catch (e) {
     utils.log.error(e);
-    if (type(callback) === 'function') {
-      callback(0, 'No request sent', {reason: 'Request failed (e.g. it was blocked).'});
-    }
   }
 };
 
@@ -1597,6 +1594,7 @@ AmplitudeClient.prototype.sendEvents = function sendEvents() {
       //  here.
       // }
     } catch (e) {
+      scope.removeEvents(Infinity, Infinity, 0, 'No request sent', {reason: 'Request failed (e.g. it was blocked).'});
       // utils.log('failed upload');
     }
   });

--- a/src/amplitude-client.js
+++ b/src/amplitude-client.js
@@ -1281,6 +1281,9 @@ AmplitudeClient.prototype._logEvent = function _logEvent(eventType, eventPropert
     return eventId;
   } catch (e) {
     utils.log.error(e);
+    if (type(callback) === 'function') {
+      callback(0, 'No request sent', {reason: 'Request failed (e.g. it was blocked).'});
+    }
   }
 };
 


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude JavaScript SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

<!-- What does the PR do? -->

Fire callback, if user blocks Amplitude.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-JavaScript/blob/master/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->

_Potentially?_ The behaviour changes to some degree, but it was always possible to call `callback(0, 'No request sent', {reason: '...'})`. So the user should be prepared for that.