### PR TITLE
fix: Bug with logEvent callbacks not being called when unsent events are dropped 

### DIFF
--- a/src/amplitude-client.js
+++ b/src/amplitude-client.js
@@ -1384,7 +1384,14 @@ var _generateApiPropertiesTrackingConfig = function _generateApiPropertiesTracki
  */
 AmplitudeClient.prototype._limitEventsQueued = function _limitEventsQueued(queue) {
   if (queue.length > this.options.savedMaxCount) {
-    queue.splice(0, queue.length - this.options.savedMaxCount);
+    const deletedEvents = queue.splice(0, queue.length - this.options.savedMaxCount);
+    deletedEvents.forEach((e) => {
+      if (type(e.callback) === 'function') {
+        e.callback(0, 'No request sent', {
+          reason: 'Event dropped because options.savedMaxCount exceeded. User may be offline or have a content blocker',
+        });
+      }
+    });
   }
 };
 

--- a/src/amplitude-client.js
+++ b/src/amplitude-client.js
@@ -1684,8 +1684,7 @@ AmplitudeClient.prototype.sendEvents = function sendEvents() {
       //  here.
       // }
     } catch (e) {
-      scope.removeEvents(Infinity, Infinity, 0, 'No request sent', {reason: 'Request failed (e.g. it was blocked).'});
-      // utils.log('failed upload');
+      // utils.log.error('failed upload');
     }
   });
 };

--- a/src/amplitude-client.js
+++ b/src/amplitude-client.js
@@ -1358,9 +1358,6 @@ AmplitudeClient.prototype._logEvent = function _logEvent(
     return eventId;
   } catch (e) {
     utils.log.error(e);
-    if (type(callback) === 'function') {
-      callback(0, 'No request sent', {reason: 'Request failed (e.g. it was blocked).'});
-    }
   }
 };
 
@@ -1687,6 +1684,7 @@ AmplitudeClient.prototype.sendEvents = function sendEvents() {
       //  here.
       // }
     } catch (e) {
+      scope.removeEvents(Infinity, Infinity, 0, 'No request sent', {reason: 'Request failed (e.g. it was blocked).'});
       // utils.log('failed upload');
     }
   });

--- a/src/amplitude-client.js
+++ b/src/amplitude-client.js
@@ -1358,6 +1358,9 @@ AmplitudeClient.prototype._logEvent = function _logEvent(
     return eventId;
   } catch (e) {
     utils.log.error(e);
+    if (type(callback) === 'function') {
+      callback(0, 'No request sent', {reason: 'Request failed (e.g. it was blocked).'});
+    }
   }
 };
 

--- a/src/amplitude-client.js
+++ b/src/amplitude-client.js
@@ -1394,6 +1394,7 @@ AmplitudeClient.prototype._limitEventsQueued = function _limitEventsQueued(queue
  * @callback Amplitude~eventCallback
  * @param {number} responseCode - Server response code for the event / identify upload request.
  * @param {string} responseBody - Server response body for the event / identify upload request.
+ * @param {object} details - (optional) Additional information associated with sending event.
  */
 
 /**

--- a/src/amplitude-client.js
+++ b/src/amplitude-client.js
@@ -1385,9 +1385,9 @@ var _generateApiPropertiesTrackingConfig = function _generateApiPropertiesTracki
 AmplitudeClient.prototype._limitEventsQueued = function _limitEventsQueued(queue) {
   if (queue.length > this.options.savedMaxCount) {
     const deletedEvents = queue.splice(0, queue.length - this.options.savedMaxCount);
-    deletedEvents.forEach((e) => {
-      if (type(e.callback) === 'function') {
-        e.callback(0, 'No request sent', {
+    deletedEvents.forEach((event) => {
+      if (type(event.callback) === 'function') {
+        event.callback(0, 'No request sent', {
           reason: 'Event dropped because options.savedMaxCount exceeded. User may be offline or have a content blocker',
         });
       }

--- a/test/amplitude-client.js
+++ b/test/amplitude-client.js
@@ -1945,6 +1945,33 @@ describe('AmplitudeClient', function () {
       assert.equal(message, 'success');
     });
 
+    it.only('should run the callback even with a dropped unsent event', function () {
+      amplitude.init(apiKey, null, { savedMaxCount: 1 });
+      var counter = 0;
+      var value = null;
+      var message = null;
+      var reason = null;
+      var callback = function (status, response, details) {
+        counter++;
+        value = status;
+        message = response;
+        reason = details.reason;
+      };
+      amplitude.logEvent('DroppedEvent', {}, callback);
+      amplitude.logEvent('SavedEvent', {}, callback);
+      server.respondWith([0, {}, '']);
+      server.respond();
+
+      // verify callback fired
+      assert.equal(counter, 1);
+      assert.equal(value, 0);
+      assert.equal(message, 'No request sent');
+      assert.equal(
+        reason,
+        'Event dropped because options.savedMaxCount exceeded. User may be offline or have a content blocker',
+      );
+    });
+
     it('should run callback once and only after 413 resolved', function () {
       var counter = 0;
       var value = -1;


### PR DESCRIPTION
### Summary

<!-- What does the PR do? -->
- Failed events (e.g. offline user or content blocker) are stored in local storage to be resent at a later time
- When the number of saved events in local storage exceeds [`maxSavedCount`](https://github.com/amplitude/Amplitude-JavaScript/blob/fix-logevent-callback-on-fail/src/options.js#L42), the oldest events will be dropped but the associated callback won't be called. This PR fixes this
- Fixes #142
- Closes #329 


### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-JavaScript/blob/master/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no --> NO
