### PR TITLE
fix(lint): Do not directly call object builtins 

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,8 +7,7 @@
     "ecmaVersion": 2018
   },
   "rules": {
-    "prettier/prettier": "error",
-    "no-prototype-builtins": "off"
+    "prettier/prettier": "error"
   },
   "globals": {
     "BUILD_COMPAT_REACT_NATIVE": "readonly",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "date-fns": "^1.30.1",
     "eslint": "^7.15.0",
     "eslint-config-prettier": "^7.0.0",
-    "eslint-plugin-prettier": "^3.3.0",
+    "eslint-plugin-prettier": "^3.3.1",
     "express": "^4.16.2",
     "fs-extra": "^4.0.2",
     "husky": "^4.3.6",

--- a/src/amplitude-client.js
+++ b/src/amplitude-client.js
@@ -431,7 +431,7 @@ var _parseConfig = function _parseConfig(options, config) {
 
   // validates config value is defined, is the correct type, and some additional value sanity checks
   var parseValidateAndLoad = function parseValidateAndLoad(key) {
-    if (!options.hasOwnProperty(key)) {
+    if (!Object.prototype.hasOwnProperty.call(options, key)) {
       return; // skip bogus config values
     }
 
@@ -453,7 +453,7 @@ var _parseConfig = function _parseConfig(options, config) {
   };
 
   for (var key in config) {
-    if (config.hasOwnProperty(key)) {
+    if (Object.prototype.hasOwnProperty.call(config, key)) {
       parseValidateAndLoad(key);
     }
   }
@@ -769,7 +769,7 @@ var _sendParamsReferrerUserProperties = function _sendParamsReferrerUserProperti
   // setOnce the initial user properties
   var identify = new Identify();
   for (var key in userProperties) {
-    if (userProperties.hasOwnProperty(key)) {
+    if (Object.prototype.hasOwnProperty.call(userProperties, key)) {
       identify.setOnce('initial_' + key, userProperties[key]);
       identify.set(key, userProperties[key]);
     }
@@ -1076,7 +1076,7 @@ AmplitudeClient.prototype.setUserProperties = function setUserProperties(userPro
   // convert userProperties into an identify call
   var identify = new Identify();
   for (var property in sanitized) {
-    if (sanitized.hasOwnProperty(property)) {
+    if (Object.prototype.hasOwnProperty.call(sanitized, property)) {
       identify.set(property, sanitized[property]);
     }
   }
@@ -1140,7 +1140,7 @@ AmplitudeClient.prototype.identify = function (identify_obj, opt_callback) {
   }
 
   // if identify input is a proxied object created by the async loading snippet, convert it into an identify object
-  if (type(identify_obj) === 'object' && identify_obj.hasOwnProperty('_q')) {
+  if (Object.prototype.hasOwnProperty.call(identify_obj, '_q')) {
     identify_obj = _convertProxyObjectToRealObject(new Identify(), identify_obj);
   }
 
@@ -1196,7 +1196,7 @@ AmplitudeClient.prototype.groupIdentify = function (group_type, group_name, iden
   }
 
   // if identify input is a proxied object created by the async loading snippet, convert it into an identify object
-  if (type(identify_obj) === 'object' && identify_obj.hasOwnProperty('_q')) {
+  if (Object.prototype.hasOwnProperty.call(identify_obj, '_q')) {
     identify_obj = _convertProxyObjectToRealObject(new Identify(), identify_obj);
   }
 
@@ -1524,7 +1524,7 @@ AmplitudeClient.prototype.logRevenueV2 = function logRevenueV2(revenue_obj) {
   }
 
   // if revenue input is a proxied object created by the async loading snippet, convert it into an revenue object
-  if (type(revenue_obj) === 'object' && revenue_obj.hasOwnProperty('_q')) {
+  if (Object.prototype.hasOwnProperty.call(revenue_obj, '_q')) {
     revenue_obj = _convertProxyObjectToRealObject(new Revenue(), revenue_obj);
   }
 

--- a/src/amplitude-snippet.js
+++ b/src/amplitude-snippet.js
@@ -82,7 +82,7 @@
   setUpProxy(amplitude);
   amplitude.getInstance = function (instance) {
     instance = (!instance || instance.length === 0 ? '$default_instance' : instance).toLowerCase();
-    if (!amplitude._iq.hasOwnProperty(instance)) {
+    if (!Object.prototype.hasOwnProperty.call(amplitude._iq, instance)) {
       amplitude._iq[instance] = { _q: [] };
       setUpProxy(amplitude._iq[instance]);
     }

--- a/src/amplitude.js
+++ b/src/amplitude.js
@@ -55,7 +55,7 @@ if (BUILD_COMPAT_SNIPPET) {
 
     // run queued up functions on instances
     for (var instance in this._instances) {
-      if (this._instances.hasOwnProperty(instance)) {
+      if (Object.prototype.hasOwnProperty.call(this._instances, instance)) {
         this._instances[instance].runQueuedFunctions();
       }
     }

--- a/src/identify.js
+++ b/src/identify.js
@@ -78,7 +78,7 @@ Identify.prototype.append = function (property, value) {
  */
 Identify.prototype.clearAll = function () {
   if (Object.keys(this.userPropertiesOperations).length > 0) {
-    if (!this.userPropertiesOperations.hasOwnProperty(AMP_OP_CLEAR_ALL)) {
+    if (!Object.prototype.hasOwnProperty.call(this.userPropertiesOperations, AMP_OP_CLEAR_ALL)) {
       utils.log.error(
         'Need to send $clearAll on its own Identify object without any other operations, skipping $clearAll',
       );
@@ -163,7 +163,7 @@ Identify.prototype.unset = function (property) {
  */
 Identify.prototype._addOperation = function (operation, property, value) {
   // check that the identify doesn't already contain a clearAll
-  if (this.userPropertiesOperations.hasOwnProperty(AMP_OP_CLEAR_ALL)) {
+  if (Object.prototype.hasOwnProperty.call(this.userPropertiesOperations, AMP_OP_CLEAR_ALL)) {
     utils.log.error('This identify already contains a $clearAll operation, skipping operation ' + operation);
     return;
   }
@@ -174,7 +174,7 @@ Identify.prototype._addOperation = function (operation, property, value) {
     return;
   }
 
-  if (!this.userPropertiesOperations.hasOwnProperty(operation)) {
+  if (!Object.prototype.hasOwnProperty.call(this.userPropertiesOperations, operation)) {
     this.userPropertiesOperations[operation] = {};
   }
   this.userPropertiesOperations[operation][property] = value;

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,7 @@ newInstance._q = old._q || [];
  */
 for (let instance in old._iq) {
   // migrate each instance's queue
-  if (old._iq.hasOwnProperty(instance)) {
+  if (Object.prototype.hasOwnProperty.call(old._iq, instance)) {
     newInstance.getInstance(instance)._q = old._iq[instance]._q || [];
   }
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -11,7 +11,7 @@ var logLevels = {
 let logLevel = logLevels.WARN;
 
 const setLogLevel = function setLogLevel(logLevelName) {
-  if (logLevelName in logLevels) {
+  if (Object.prototype.hasOwnProperty.call(logLevels, logLevel)) {
     logLevel = logLevels[logLevelName];
   }
 };
@@ -112,7 +112,7 @@ var validateProperties = function validateProperties(properties) {
 
   var copy = {}; // create a copy with all of the valid properties
   for (var property in properties) {
-    if (!(property in properties)) {
+    if (!Object.prototype.hasOwnProperty.call(properties, property)) {
       continue;
     }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -11,7 +11,7 @@ var logLevels = {
 let logLevel = logLevels.WARN;
 
 const setLogLevel = function setLogLevel(logLevelName) {
-  if (logLevels.hasOwnProperty(logLevelName)) {
+  if (logLevelName in logLevels) {
     logLevel = logLevels[logLevelName];
   }
 };
@@ -177,7 +177,7 @@ var validateGroups = function validateGroups(groups) {
 
   var copy = {}; // create a copy with all of the valid properties
   for (var group in groups) {
-    if (!groups.hasOwnProperty(group)) {
+    if (!Object.prototype.hasOwnProperty.call(groups, group)) {
       continue;
     }
 

--- a/test/browser/.eslintrc.json
+++ b/test/browser/.eslintrc.json
@@ -1,0 +1,6 @@
+{
+  "rules": {
+    "prettier/prettier": "error",
+    "no-prototype-builtins": "off"
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2806,10 +2806,10 @@ eslint-config-prettier@^7.0.0:
   resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-7.0.0.tgz#c1ae4106f74e6c0357f44adb076771d032ac0e97"
   integrity sha512-8Y8lGLVPPZdaNA7JXqnvETVC7IiVRgAP6afQu9gOQRn90YY3otMNh+x7Vr2vMePQntF+5erdSUBqSzCmU/AxaQ==
 
-eslint-plugin-prettier@^3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.3.0.tgz#61e295349a65688ffac0b7808ef0a8244bdd8d40"
-  integrity sha512-tMTwO8iUWlSRZIwS9k7/E4vrTsfvsrcM5p1eftyuqWH25nKsz/o6/54I7jwQ/3zobISyC7wMy9ZsFwgTxOcOpQ==
+eslint-plugin-prettier@^3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.3.1.tgz#7079cfa2497078905011e6f82e8dd8453d1371b7"
+  integrity sha512-Rq3jkcFY8RYeQLgk2cCwuc0P7SEFwDravPhsJZOQ5N4YI4DSg50NyqJ/9gdZHzQlHf8MvafSesbNJCcP/FF6pQ==
   dependencies:
     prettier-linter-helpers "^1.0.0"
 


### PR DESCRIPTION

### Summary

We are heavy users of the Object prototype `hasOwnProperty`. In general, these should not be called directly - especially on user-created inputs. Allows a lint override to be removed.

Did not add it to the `tests/browsers` dir because I'm not linting sinon or chai 🤷 

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-JavaScript/blob/master/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
