### PR TITLE
fix: call onError in init function

### DIFF
--- a/src/amplitude-client.js
+++ b/src/amplitude-client.js
@@ -444,7 +444,8 @@ var _parseConfig = function _parseConfig(options, config) {
       options[key] = !!inputValue;
     } else if (
       (expectedType === 'string' && !utils.isEmptyString(inputValue)) ||
-      (expectedType === 'number' && inputValue > 0)
+      (expectedType === 'number' && inputValue > 0) ||
+      expectedType === 'function'
     ) {
       options[key] = inputValue;
     } else if (expectedType === 'object') {

--- a/src/amplitude-client.js
+++ b/src/amplitude-client.js
@@ -275,7 +275,9 @@ AmplitudeClient.prototype.init = function init(apiKey, opt_userId, opt_config, o
     }
   } catch (err) {
     utils.log.error(err);
-    this.options.onError(err);
+    if (type(opt_config.onError) === 'function') {
+      opt_config.onError(err);
+    }
   }
 };
 

--- a/test/amplitude-client.js
+++ b/test/amplitude-client.js
@@ -824,6 +824,17 @@ describe('AmplitudeClient', function () {
         },
       });
     });
+
+    it('should call the supplied onError function if an error occurs during init()', () => {
+      var onErrorSpy = sinon.spy();
+
+      var amplitude = new AmplitudeClient();
+      sinon.stub(amplitude.cookieStorage, 'options').throws();
+      amplitude.init(apiKey, null, { onError: onErrorSpy });
+      assert.isTrue(onErrorSpy.calledOnce);
+
+      amplitude.cookieStorage.options.restore();
+    });
   });
 
   describe('runQueuedFunctions', function () {


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude JavaScript SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Use SDK consumer-supplied `onError` function throughout the codebase and make sure it is properly invoked if an error occurs during initialization

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-JavaScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
