### PR TITLE
fix: remove argument to function that takes no arguments

### DIFF
--- a/src/amplitude-client.js
+++ b/src/amplitude-client.js
@@ -1353,7 +1353,7 @@ AmplitudeClient.prototype._logEvent = function _logEvent(
       this.saveEvents();
     }
 
-    this._sendEventsIfReady(callback);
+    this._sendEventsIfReady();
 
     return eventId;
   } catch (e) {


### PR DESCRIPTION

### Summary

Not a bug, but would be confusing down the line. `sendEventsIfReady` takes no args.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-JavaScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
