### PR TITLE
fix:  Cleanup test cookies

### DIFF
--- a/src/base-cookie.js
+++ b/src/base-cookie.js
@@ -57,9 +57,9 @@ const areCookiesEnabled = (opts = {}) => {
     set(cookieName, uid, opts);
     _areCookiesEnabled = get(cookieName + '=') === uid;
   } catch (e) {
-    utils.warn.info(`Cookies are unavailable. Reason: "${e}"`);
+    utils.log.warn(`Cookies are unavailable. Reason: "${e}"`);
   } finally {
-    utils.warn.info(`Cleaning up cookies availability test`);
+    utils.log.warn(`Cleaning up cookies availability test`);
     set(cookieName, null, opts);
   }
   return _areCookiesEnabled;

--- a/src/base-cookie.js
+++ b/src/base-cookie.js
@@ -49,12 +49,12 @@ const set = (name, value, opts) => {
 
 // test that cookies are enabled - navigator.cookiesEnabled yields false positives in IE, need to test directly
 const areCookiesEnabled = (opts = {}) => {
-  utils.log.info(`Testing if cookies available`);
   const cookieName = Constants.COOKIE_TEST_PREFIX + base64Id();
   let _areCookiesEnabled = false;
   try {
     const uid = String(new Date());
     set(cookieName, uid, opts);
+    utils.log.info(`Testing if cookies available`);
     _areCookiesEnabled = get(cookieName + '=') === uid;
   } catch (e) {
     utils.log.warn(`Error thrown when checking for cookies. Reason: "${e}"`);

--- a/src/base-cookie.js
+++ b/src/base-cookie.js
@@ -57,10 +57,8 @@ const areCookiesEnabled = (opts = {}) => {
     set(cookieName, uid, opts);
     _areCookiesEnabled = get(cookieName + '=') === uid;
   } catch (e) {
-    console.log('error');
     utils.log.info(`Cookies are unavailable. Reason: "${e}"`);
   } finally {
-    console.log('cleanup');
     utils.log.info(`Cleaning up cookies availability test`);
     set(cookieName, null, opts);
   }

--- a/src/base-cookie.js
+++ b/src/base-cookie.js
@@ -1,5 +1,6 @@
 import Constants from './constants';
 import base64Id from './base64Id';
+import utils from './utils';
 
 const get = (name) => {
   try {
@@ -48,15 +49,22 @@ const set = (name, value, opts) => {
 
 // test that cookies are enabled - navigator.cookiesEnabled yields false positives in IE, need to test directly
 const areCookiesEnabled = (opts = {}) => {
-  const uid = String(new Date());
+  utils.log.info(`Testing if cookies available`);
+  const cookieName = Constants.COOKIE_TEST_PREFIX + base64Id();
+  let _areCookiesEnabled = false;
   try {
-    const cookieName = Constants.COOKIE_TEST_PREFIX + base64Id();
+    const uid = String(new Date());
     set(cookieName, uid, opts);
-    const _areCookiesEnabled = get(cookieName + '=') === uid;
+    _areCookiesEnabled = get(cookieName + '=') === uid;
+  } catch (e) {
+    console.log('error');
+    utils.log.info(`Cookies are unavailable. Reason: "${e}"`);
+  } finally {
+    console.log('cleanup');
+    utils.log.info(`Cleaning up cookies availability test`);
     set(cookieName, null, opts);
-    return _areCookiesEnabled;
-  } catch (e) {} /* eslint-disable-line no-empty */
-  return false;
+  }
+  return _areCookiesEnabled;
 };
 
 export default {

--- a/src/base-cookie.js
+++ b/src/base-cookie.js
@@ -57,9 +57,9 @@ const areCookiesEnabled = (opts = {}) => {
     set(cookieName, uid, opts);
     _areCookiesEnabled = get(cookieName + '=') === uid;
   } catch (e) {
-    utils.log.info(`Cookies are unavailable. Reason: "${e}"`);
+    utils.warn.info(`Cookies are unavailable. Reason: "${e}"`);
   } finally {
-    utils.log.info(`Cleaning up cookies availability test`);
+    utils.warn.info(`Cleaning up cookies availability test`);
     set(cookieName, null, opts);
   }
   return _areCookiesEnabled;

--- a/src/base-cookie.js
+++ b/src/base-cookie.js
@@ -57,7 +57,7 @@ const areCookiesEnabled = (opts = {}) => {
     set(cookieName, uid, opts);
     _areCookiesEnabled = get(cookieName + '=') === uid;
   } catch (e) {
-    utils.log.warn(`Cookies are unavailable. Reason: "${e}"`);
+    utils.log.warn(`Error thrown when checking for cookies. Reason: "${e}"`);
   } finally {
     utils.log.warn(`Cleaning up cookies availability test`);
     set(cookieName, null, opts);

--- a/test/base-cookie.js
+++ b/test/base-cookie.js
@@ -51,23 +51,26 @@ describe('cookie', function () {
   });
 
   describe('areCookiesEnabled', () => {
-    describe('when it can write to a cookie', () => {
-      afterEach(() => {
-        restoreCookie();
-      });
+    before(() => {
+      sinon.stub(Math, 'random').returns(1);
+    });
+    after(() => {
+      sinon.restore();
+    });
+    afterEach(() => {
+      restoreCookie();
+      sinon.restore();
+    });
 
+    describe('when it can write to a cookie', () => {
       it('should return true', () => {
         assert.isTrue(cookie.areCookiesEnabled());
       });
 
       it('should cleanup cookies', () => {
-        const stub = sinon.stub(Math, 'random').returns(12345678);
-
         const cookieName = Constants.COOKIE_TEST_PREFIX + base64Id();
         cookie.areCookiesEnabled();
         assert.isNull(cookie.get(`${cookieName}=`), null);
-
-        stub.restore();
       });
     });
 
@@ -76,38 +79,28 @@ describe('cookie', function () {
         mockCookie({ disabled: true });
       });
 
-      afterEach(() => {
-        restoreCookie();
-      });
-
       it('should return false', () => {
         assert.isFalse(cookie.areCookiesEnabled());
       });
 
       it('should cleanup cookies', () => {
-        const stub = sinon.stub(Math, 'random').returns(12345678);
         const cookieName = Constants.COOKIE_TEST_PREFIX + base64Id();
 
         cookie.areCookiesEnabled();
         assert.isNull(cookie.get(`${cookieName}=`));
-
-        stub.restore();
       });
     });
 
     describe('when error is thrown during check', () => {
       it('should cleanup cookies', () => {
-        const stub = sinon.stub(Math, 'random').returns(12345678);
         const stubLogInfo = sinon.stub(utils.log, 'info').throws('Stubbed Exception');
         const spyLogWarning = sinon.spy(utils.log, 'warn');
         const cookieName = Constants.COOKIE_TEST_PREFIX + base64Id();
-
         const res = cookie.areCookiesEnabled();
         assert.isFalse(res);
         assert.isTrue(spyLogWarning.calledWith('Error thrown when checking for cookies. Reason: "Stubbed Exception"'));
         assert.isNull(cookie.get(`${cookieName}=`));
 
-        stub.restore();
         stubLogInfo.restore();
         spyLogWarning.restore();
       });


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude JavaScript SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

- Add `finally` codeblock to handle cleanup of `amp_cookie_test`.  Will stop excess cookies in header requests.
- Fixes #326

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-JavaScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no --> NO
