### PR TITLE
feat: Clear Storage API

### DIFF
--- a/src/amplitude-client.js
+++ b/src/amplitude-client.js
@@ -522,6 +522,16 @@ AmplitudeClient.prototype._sendEventsIfReady = function _sendEventsIfReady() {
 };
 
 /**
+ * Clears any saved metadata storage
+ * @constructor AmplitudeClient
+ * @public
+ * @return {boolean} True if metadata was cleared, false if none existed
+ */
+AmplitudeClient.prototype.clearStorage = function clearStorage() {
+  return this._metadataStorage.clear();
+};
+
+/**
  * Helper function to fetch values from storage
  * Storage argument allows for localStoraoge and sessionStoraoge
  * @private

--- a/src/amplitude-client.js
+++ b/src/amplitude-client.js
@@ -522,7 +522,7 @@ AmplitudeClient.prototype._sendEventsIfReady = function _sendEventsIfReady() {
 };
 
 /**
- * Clears any saved metadata storage
+ * Clears any stored events and metadata. Storage is then re-created on next event sending.
  * @constructor AmplitudeClient
  * @public
  * @return {boolean} True if metadata was cleared, false if none existed

--- a/src/base-cookie.js
+++ b/src/base-cookie.js
@@ -92,6 +92,14 @@ const sortByEventTime = (cookies) => {
   });
 };
 
+/**
+ * Clears cookie by setting expiration to a past date
+ * @param {*} name
+ */
+const clear = (name) => {
+  document.cookie = `${name}= ; expires = Thu, 01 Jan 1970 00:00:00 GMT'`;
+};
+
 // test that cookies are enabled - navigator.cookiesEnabled yields false positives in IE, need to test directly
 const areCookiesEnabled = (opts = {}) => {
   const cookieName = Constants.COOKIE_TEST_PREFIX + base64Id();
@@ -113,6 +121,7 @@ const areCookiesEnabled = (opts = {}) => {
 export default {
   set,
   get,
+  clear,
   getAll,
   getLastEventTime,
   sortByEventTime,

--- a/src/base-cookie.js
+++ b/src/base-cookie.js
@@ -92,14 +92,6 @@ const sortByEventTime = (cookies) => {
   });
 };
 
-/**
- * Clears cookie by setting expiration to a past date
- * @param {*} name
- */
-const clear = (name) => {
-  document.cookie = `${name}= ; expires = Thu, 01 Jan 1970 00:00:00 GMT'`;
-};
-
 // test that cookies are enabled - navigator.cookiesEnabled yields false positives in IE, need to test directly
 const areCookiesEnabled = (opts = {}) => {
   const cookieName = Constants.COOKIE_TEST_PREFIX + base64Id();
@@ -121,7 +113,6 @@ const areCookiesEnabled = (opts = {}) => {
 export default {
   set,
   get,
-  clear,
   getAll,
   getLastEventTime,
   sortByEventTime,

--- a/src/metadata-storage.js
+++ b/src/metadata-storage.js
@@ -163,6 +163,34 @@ class MetadataStorage {
       sequenceNumber: parseInt(values[Constants.SEQUENCE_NUMBER_INDEX], 32),
     };
   }
+
+  /**
+   * Clears any saved metadata storage
+   * @constructor AmplitudeClient
+   * @public
+   * @return {boolean} True if metadata was cleared, false if none existed
+   */
+  clear() {
+    let str;
+    if (this.storage === Constants.STORAGE_COOKIES) {
+      str = baseCookie.get(this.getCookieStorageKey() + '=');
+      baseCookie.clear(this.getCookieStorageKey());
+    }
+    if (!str) {
+      str = ampLocalStorage.getItem(this.storageKey);
+      ampLocalStorage.clear();
+    }
+    if (!str) {
+      try {
+        str = window.sessionStorage && window.sessionStorage.getItem(this.storageKey);
+        window.sessionStorage.clear();
+      } catch (e) {
+        utils.log.info(`window.sessionStorage unavailable. Reason: "${e}"`);
+      }
+    }
+    if (!str) false;
+    return true;
+  }
 }
 
 export default MetadataStorage;

--- a/src/metadata-storage.js
+++ b/src/metadata-storage.js
@@ -174,7 +174,12 @@ class MetadataStorage {
     let str;
     if (this.storage === Constants.STORAGE_COOKIES) {
       str = baseCookie.get(this.getCookieStorageKey() + '=');
-      baseCookie.clear(this.getCookieStorageKey());
+      baseCookie.set(this.getCookieStorageKey(), null, {
+        domain: this.cookieDomain,
+        secure: this.secure,
+        sameSite: this.sameSite,
+        expirationDays: 0,
+      });
     }
     if (!str) {
       str = ampLocalStorage.getItem(this.storageKey);

--- a/test/amplitude-client.js
+++ b/test/amplitude-client.js
@@ -3814,7 +3814,7 @@ describe('AmplitudeClient', function () {
       amplitude.init(apiKey, null, { storage: constants.STORAGE_COOKIES });
       assert.isNotNull(amplitude._metadataStorage.load());
       assert.equal(amplitude._metadataStorage.storage, constants.STORAGE_COOKIES);
-      amplitude.clearStorage();
+      assert.equal(amplitude.clearStorage(), true);
       assert.isNull(amplitude._metadataStorage.load());
     });
 
@@ -3822,7 +3822,7 @@ describe('AmplitudeClient', function () {
       amplitude.init(apiKey, null, { storage: constants.STORAGE_LOCAL });
       assert.isNotNull(amplitude._metadataStorage.load());
       assert.equal(amplitude._metadataStorage.storage, constants.STORAGE_LOCAL);
-      amplitude.clearStorage();
+      assert.equal(amplitude.clearStorage(), true);
       assert.isNull(amplitude._metadataStorage.load());
     });
 
@@ -3830,7 +3830,7 @@ describe('AmplitudeClient', function () {
       amplitude.init(apiKey, null, { storage: constants.STORAGE_SESSION });
       assert.isNotNull(amplitude._metadataStorage.load());
       assert.equal(amplitude._metadataStorage.storage, constants.STORAGE_SESSION);
-      amplitude.clearStorage();
+      assert.equal(amplitude.clearStorage(), true);
       assert.isNull(amplitude._metadataStorage.load());
     });
   });

--- a/test/amplitude-client.js
+++ b/test/amplitude-client.js
@@ -3804,4 +3804,34 @@ describe('AmplitudeClient', function () {
       });
     });
   });
+
+  describe('clearStorage', function () {
+    afterEach(() => {
+      reset();
+    });
+
+    it('should clear cookies', function () {
+      amplitude.init(apiKey, null, { storage: constants.STORAGE_COOKIES });
+      assert.isNotNull(amplitude._metadataStorage.load());
+      assert.equal(amplitude._metadataStorage.storage, constants.STORAGE_COOKIES);
+      amplitude.clearStorage();
+      assert.isNull(amplitude._metadataStorage.load());
+    });
+
+    it('should clear localStorage', function () {
+      amplitude.init(apiKey, null, { storage: constants.STORAGE_LOCAL });
+      assert.isNotNull(amplitude._metadataStorage.load());
+      assert.equal(amplitude._metadataStorage.storage, constants.STORAGE_LOCAL);
+      amplitude.clearStorage();
+      assert.isNull(amplitude._metadataStorage.load());
+    });
+
+    it('should clear sessionStorage', function () {
+      amplitude.init(apiKey, null, { storage: constants.STORAGE_SESSION });
+      assert.isNotNull(amplitude._metadataStorage.load());
+      assert.equal(amplitude._metadataStorage.storage, constants.STORAGE_SESSION);
+      amplitude.clearStorage();
+      assert.isNull(amplitude._metadataStorage.load());
+    });
+  });
 });


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude JavaScript SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Adds an API to AmplitudeClient `clearStorage` that wipes user metadata. Escape hatch to help weird edge cases where user's datastorage is malformed somehow.

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-JavaScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no --> NO
