### PR TITLE
fix: Prevent periods in device id check

### DIFF
--- a/src/amplitude-client.js
+++ b/src/amplitude-client.js
@@ -927,8 +927,9 @@ AmplitudeClient.prototype.regenerateDeviceId = function regenerateDeviceId() {
 };
 
 /**
- * Sets a custom deviceId for current user. Note: this is not recommended unless you know what you are doing
- * (like if you have your own system for managing deviceIds). Make sure the deviceId you set is sufficiently unique
+ * Sets a custom deviceId for current user. **Values may not have `.` inside them**
+ * Note: this is not recommended unless you know what you are doing (like if you have your own system for managing deviceIds).
+ * Make sure the deviceId you set is sufficiently unique
  * (we recommend something like a UUID - see src/uuid.js for an example of how to generate) to prevent conflicts with other devices in our system.
  * @public
  * @param {string} deviceId - custom deviceId for current user.
@@ -939,7 +940,7 @@ AmplitudeClient.prototype.setDeviceId = function setDeviceId(deviceId) {
     return this._q.push(['setDeviceId'].concat(Array.prototype.slice.call(arguments, 0)));
   }
 
-  if (!utils.validateInput(deviceId, 'deviceId', 'string')) {
+  if (!utils.validateDeviceId(deviceId)) {
     return;
   }
 

--- a/src/amplitude-client.js
+++ b/src/amplitude-client.js
@@ -148,6 +148,12 @@ AmplitudeClient.prototype.init = function init(apiKey, opt_userId, opt_config, o
     this._pendingReadStorage = true;
 
     const initFromStorage = (storedDeviceId) => {
+      if (opt_config && opt_config.deviceId && !utils.validateDeviceId(opt_config.deviceId)) {
+        utils.log.error(
+          `Invalid device ID rejected. Randomly generated UUID will be used instead of "${opt_config.deviceId}"`,
+        );
+        delete opt_config.deviceId;
+      }
       this.options.deviceId = this._getInitialDeviceId(opt_config && opt_config.deviceId, storedDeviceId);
       this.options.userId =
         (type(opt_userId) === 'string' && !utils.isEmptyString(opt_userId) && opt_userId) ||

--- a/src/utils.js
+++ b/src/utils.js
@@ -97,6 +97,19 @@ var validateInput = function validateInput(input, name, expectedType) {
   return true;
 };
 
+const validateDeviceId = function validateDeviceId(deviceId) {
+  if (!validateInput(deviceId, 'deviceId', 'string')) {
+    return false;
+  }
+  for (let i = 0; i < deviceId.length; i++) {
+    if (deviceId[i] === '.') {
+      log.error(`Device IDs may not contain '.' characters. Value will be ignored: "${deviceId}"`);
+      return false;
+    }
+  }
+  return true;
+};
+
 // do some basic sanitization and type checking, also catch property dicts with more than 1000 key/value pairs
 var validateProperties = function validateProperties(properties) {
   var propsType = type(properties);
@@ -257,4 +270,5 @@ export default {
   validateGroups,
   validateInput,
   validateProperties,
+  validateDeviceId,
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -101,11 +101,9 @@ const validateDeviceId = function validateDeviceId(deviceId) {
   if (!validateInput(deviceId, 'deviceId', 'string')) {
     return false;
   }
-  for (let i = 0; i < deviceId.length; i++) {
-    if (deviceId[i] === '.') {
-      log.error(`Device IDs may not contain '.' characters. Value will be ignored: "${deviceId}"`);
-      return false;
-    }
+  if (deviceId.includes('.')) {
+    log.error(`Device IDs may not contain '.' characters. Value will be ignored: "${deviceId}"`);
+    return false;
   }
   return true;
 };

--- a/test/amplitude-client.js
+++ b/test/amplitude-client.js
@@ -289,6 +289,12 @@ describe('AmplitudeClient', function () {
       const spyErrorWarning = sinon.spy(utils.log, 'error');
       const badDeviceId = 'bad.device.id';
       amplitude.init(apiKey, null, { deviceId: badDeviceId });
+
+      assert.isTrue(
+        spyErrorWarning.calledWith(
+          `Device IDs may not contain '.' characters. Value will be ignored: "${badDeviceId}"`,
+        ),
+      );
       assert.isTrue(
         spyErrorWarning.calledWith(
           `Invalid device ID rejected. Randomly generated UUID will be used instead of "${badDeviceId}"`,

--- a/test/amplitude-client.js
+++ b/test/amplitude-client.js
@@ -1071,7 +1071,9 @@ describe('AmplitudeClient', function () {
       var stored = amplitude._metadataStorage.load();
       assert.propertyVal(stored, 'deviceId', 'fakeDeviceId');
       assert.isTrue(
-        spyErrorWarning.calledWith(`Device IDs may not contain '.' characters. Value will be ignored "${badDeviceId}"`),
+        spyErrorWarning.calledWith(
+          `Device IDs may not contain '.' characters. Value will be ignored: "${badDeviceId}"`,
+        ),
       );
       spyErrorWarning.restore();
     });

--- a/test/amplitude-client.js
+++ b/test/amplitude-client.js
@@ -285,6 +285,20 @@ describe('AmplitudeClient', function () {
       amplitude._getUrlParams.restore();
     });
 
+    it('should reject invalid device ids that contain periods', function () {
+      const spyErrorWarning = sinon.spy(utils.log, 'error');
+      const badDeviceId = 'bad.device.id';
+      amplitude.init(apiKey, null, { deviceId: badDeviceId });
+      assert.isTrue(
+        spyErrorWarning.calledWith(
+          `Invalid device ID rejected. Randomly generated UUID will be used instead of "${badDeviceId}"`,
+        ),
+      );
+      assert.notEqual(amplitude.options.deviceId, badDeviceId);
+
+      spyErrorWarning.restore();
+    });
+
     it('should load device id from the cookie', function () {
       // deviceId and sequenceNumber not set, init should load value from localStorage
       var cookieData = {
@@ -1047,6 +1061,19 @@ describe('AmplitudeClient', function () {
       amplitude.setDeviceId('deviceId');
       var stored = amplitude._metadataStorage.load();
       assert.propertyVal(stored, 'deviceId', 'deviceId');
+    });
+
+    it('should not take periods in deviceId', function () {
+      const spyErrorWarning = sinon.spy(utils.log, 'error');
+      amplitude.init(apiKey, null, { deviceId: 'fakeDeviceId' });
+      const badDeviceId = 'bad.device.id';
+      amplitude.setDeviceId(badDeviceId);
+      var stored = amplitude._metadataStorage.load();
+      assert.propertyVal(stored, 'deviceId', 'fakeDeviceId');
+      assert.isTrue(
+        spyErrorWarning.calledWith(`Device IDs may not contain '.' characters. Value will be ignored "${badDeviceId}"`),
+      );
+      spyErrorWarning.restore();
     });
   });
 


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude JavaScript SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Periods in device ID checks broke the SDK storage behavior. This is because metadata is stored in cookies and delimited by periods. This PR fixes the behavior by rejecting device IDs with periods

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-JavaScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no --> NO
