### PR TITLE
fix: allow amplitude to be imported/required during SSR

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 // Entry point
 import Amplitude from './amplitude';
 
-const old = window.amplitude || {};
+const old = (typeof window !== 'undefined' && window.amplitude) || {};
 const newInstance = new Amplitude();
 newInstance._q = old._q || [];
 

--- a/src/language.js
+++ b/src/language.js
@@ -1,6 +1,7 @@
 var getLanguage = function () {
   return (
-    (navigator && ((navigator.languages && navigator.languages[0]) || navigator.language || navigator.userLanguage)) ||
+    (typeof navigator !== 'undefined' &&
+      ((navigator.languages && navigator.languages[0]) || navigator.language || navigator.userLanguage)) ||
     ''
   );
 };

--- a/src/localstorage.js
+++ b/src/localstorage.js
@@ -26,7 +26,7 @@ if (BUILD_COMPAT_LOCAL_STORAGE) {
 
   if (windowLocalStorageAvailable()) {
     localStorage = window.localStorage;
-  } else if (window.globalStorage) {
+  } else if (typeof window !== 'undefined' && window.globalStorage) {
     // Firefox 2-3 use globalStorage
     // See https://developer.mozilla.org/en/dom/storage#globalStorage
     try {


### PR DESCRIPTION
### Summary

We have a number of NextJS applications using amplitude, but we currently need to do something like the following to be able to use the library:
```js
  useEffect(() => {
    import('amplitude-js').then((amplitude) => {
      amplitude.getInstance().init(API_KEY);
      amplitude.getInstance().logEvent('foo');
    });
  }, []);
```

If instead we were to have a static

```
import amplitude from 'amplitude-js'
```

at the top of our modules, we'd see errors due to amplitude trying to access global browser variables such as `window` and `navigator` when trying to load the module.

While I understand that this library is intended for use in the browser and there's a separate package for use in Node environments, our use case is to simply be able to `import` the module rather than having to use a dynamic import. We don't intend on calling any of the amplitude functions as part of the server-side render.

This PR adds the minimal amount of `typeof` checks in front of places where browser global variables were being accessed so that we could successfully `import` amplitude and build the app. We could go even further with this and add similar checks in all the places (i.e. in case functions like `getInstance` and `logEvent` were to be called during SSR) so that things fail more gracefully if you prefer.

Related:  #138 #164

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-JavaScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
