### PR TITLE
feat: add esm entry point

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "url": "https://github.com/amplitude/amplitude-javascript.git"
   },
   "main": "amplitude.umd.js",
+  "module": "amplitude.esm.js",
   "dependencies": {
     "@amplitude/ua-parser-js": "0.7.25",
     "@amplitude/utils": "^1.0.5",


### PR DESCRIPTION
### Summary

I noticed the build produces an `amplitude.esm.js` file, but is not referenced in the `package.json`. This PR adds the `module` entry point to the `package.json` so folks using ESM along with bundlers like webpack, parcel, etc will automatically use the ESM version of amplitude rather than the UMD/CJS version.

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-JavaScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
