### PR TITLE
feat: add more interface for flutter web support

### DIFF
--- a/src/amplitude-client.js
+++ b/src/amplitude-client.js
@@ -1908,28 +1908,11 @@ AmplitudeClient.prototype.__VERSION__ = function getVersion() {
  * @param {string} name - Custom library name
  * @param {string} version - Custom library version
  */
-AmplitudeClient.prototype.setLibrary = function setLibrary(name, version) {
+AmplitudeClient.prototype.setLibrary = function setLibrary(
+  name = this.options.libraryName,
+  version = this.options.libraryVersion,
+) {
   this.options.library = { name: name, version: version };
-};
-
-/**
- * Sets the library name.
- * @public
- * @param {string} libraryName - the library name.
- * @example amplitudeClient.setLibraryName('my_library_name');
- */
-AmplitudeClient.prototype.setLibraryName = function setLibraryName(libraryName) {
-  this.options.library.name = libraryName;
-};
-
-/**
- * Sets the library Version.
- * @public
- * @param {string} userId - the library version.
- * @example amplitudeClient.setLibraryVersion('1.0.0');
- */
-AmplitudeClient.prototype.setLibraryVersion = function setLibraryVersion(libraryVersion) {
-  this.options.library.version = libraryVersion;
 };
 
 /**
@@ -2063,7 +2046,7 @@ AmplitudeClient.prototype.setUseDynamicConfig = function setUseDynamicConfig(use
 };
 
 /**
- * Sets the server zone , used for server api endpoint and dynamic configuration..
+ * Sets the server zone , used for server api endpoint and dynamic configuration.
  * @public
  * @param {string} serverZone - the server zone value. AmplitudeServerZone.US or AmplitudeServerZone.EU.
  * @param {bool} serverZoneBasedApi - (optional) update api endpoint with serverZone change or not. For data residency, recommend to enable it unless using own proxy server.

--- a/src/amplitude-client.js
+++ b/src/amplitude-client.js
@@ -2046,7 +2046,7 @@ AmplitudeClient.prototype.setUseDynamicConfig = function setUseDynamicConfig(use
 };
 
 /**
- * Sets the server zone , used for server api endpoint and dynamic configuration.
+ * Sets the server zone, used for server api endpoint and dynamic configuration.
  * @public
  * @param {string} serverZone - the server zone value. AmplitudeServerZone.US or AmplitudeServerZone.EU.
  * @param {bool} serverZoneBasedApi - (optional) update api endpoint with serverZone change or not. For data residency, recommend to enable it unless using own proxy server.

--- a/src/amplitude-client.js
+++ b/src/amplitude-client.js
@@ -1435,6 +1435,7 @@ AmplitudeClient.prototype.logEvent = function logEvent(
  * @param {Amplitude~eventCallback} opt_error_callback - (optional) a callback function to run after the event logging
  * fails. The failure can be from the request being malformed or from a network failure
  * Note: the server response code and response body from the event upload are passed to the callback function.
+ * @param {boolean} outOfSession - (optional) if out of the sessioin or not
  * @example amplitudeClient.logEvent('Clicked Homepage Button', {'finished_flow': false, 'clicks': 15});
  */
 AmplitudeClient.prototype.logEventWithTimestamp = function logEvent(
@@ -1443,7 +1444,7 @@ AmplitudeClient.prototype.logEventWithTimestamp = function logEvent(
   timestamp,
   opt_callback,
   opt_error_callback,
-  outOfSession,
+  outOfSession = false,
 ) {
   if (this._shouldDeferCall()) {
     return this._q.push(['logEventWithTimestamp'].concat(Array.prototype.slice.call(arguments, 0)));

--- a/src/amplitude-client.js
+++ b/src/amplitude-client.js
@@ -2114,21 +2114,4 @@ AmplitudeClient.prototype.setServerUrl = function setServerUrl(serverUrl) {
   }
 };
 
-/**
- * Upload all unsent events.
- * @public
- * @example amplitudeClient.uploadEvents();
- */
-AmplitudeClient.prototype.uploadEvents = function uploadEvents() {
-  if (this._shouldDeferCall()) {
-    return this._q.push(['uploadEvents'].concat(Array.prototype.slice.call(arguments, 0)));
-  }
-
-  try {
-    this.sendEvents();
-  } catch (e) {
-    utils.log.error(e);
-  }
-};
-
 export default AmplitudeClient;

--- a/src/amplitude-snippet.js
+++ b/src/amplitude-snippet.js
@@ -79,6 +79,14 @@
     'logEventWithGroups',
     'setSessionId',
     'resetSessionId',
+    'getDeviceId',
+    'getUserId',
+    'setMinTimeBetweenSessionsMillis',
+    'setEventUploadThreshold',
+    'setUseDynamicConfig',
+    'setServerZone',
+    'setServerUrl',
+    'sendEvents',
   ];
   function setUpProxy(instance) {
     function proxyMain(fn) {

--- a/test/amplitude-client.js
+++ b/test/amplitude-client.js
@@ -4172,6 +4172,7 @@ describe('AmplitudeClient', function () {
     beforeEach(function () {
       reset();
     });
+
     it('should use default library options', function () {
       amplitude.init(apiKey);
       amplitude.logEvent('Event Type 1');
@@ -4199,15 +4200,10 @@ describe('AmplitudeClient', function () {
       assert.equal(name, 'test-library');
       assert.equal(version, '1.0-test');
     });
-  });
 
-  describe('libraryName', function () {
-    beforeEach(function () {
-      reset();
-    });
     it('should use the customize library name and default library version', function () {
       amplitude.init(apiKey);
-      amplitude.setLibraryName('test-library');
+      amplitude.setLibrary('test-library', undefined);
       amplitude.logEvent('Event Type');
 
       const { name, version } = JSON.parse(queryString.parse(server.requests[0].requestBody).e)[0].library;
@@ -4215,15 +4211,10 @@ describe('AmplitudeClient', function () {
       assert.equal(name, 'test-library');
       assert.equal(version, amplitude.options.library.version);
     });
-  });
 
-  describe('libraryVersion', function () {
-    beforeEach(function () {
-      reset();
-    });
     it('should use the customize library version and default library name', function () {
       amplitude.init(apiKey);
-      amplitude.setLibraryVersion('1.0-test');
+      amplitude.setLibrary(undefined, '1.0-test');
       amplitude.logEvent('Event Type');
 
       const { name, version } = JSON.parse(queryString.parse(server.requests[0].requestBody).e)[0].library;

--- a/test/amplitude-client.js
+++ b/test/amplitude-client.js
@@ -4379,22 +4379,6 @@ describe('AmplitudeClient', function () {
     });
   });
 
-  describe('uploadEvents', function () {
-    beforeEach(function () {
-      reset();
-    });
-
-    it('should flush the events', function () {
-      amplitude.init(apiKey, null, { batchEvents: true, eventUploadThreshold: 30 });
-      amplitude.logEvent('Event Type');
-      assert.equal(amplitude._unsentEvents.length, 1);
-      amplitude.uploadEvents();
-      server.respondWith('success');
-      server.respond();
-      assert.equal(amplitude._unsentEvents.length, 0);
-    });
-  });
-
   describe('setUserId', function () {
     let clock, startTime;
     beforeEach(function () {

--- a/test/amplitude-client.js
+++ b/test/amplitude-client.js
@@ -2859,8 +2859,9 @@ describe('AmplitudeClient', function () {
 
     it('should not set eventUploadThreshold with invalid eventUploadThreshold value', function () {
       amplitude.init(apiKey);
+      let previousEventUploadThreshold = amplitude.options.eventUploadThreshold;
       amplitude.setEventUploadThreshold('invalid eventUploadThreshold');
-      assert.equal(amplitude.options.eventUploadThreshold, 30);
+      assert.equal(amplitude.options.eventUploadThreshold, previousEventUploadThreshold);
     });
 
     it('should set eventUploadThreshold', function () {
@@ -2953,9 +2954,9 @@ describe('AmplitudeClient', function () {
 
     it('should not set optOut with invalid input', function () {
       amplitude.init(apiKey);
-      let optOut = 'invalid sessionTimeOut';
-      amplitude.setOptOut(optOut);
-      assert.equal(amplitude.options.optOut, false);
+      let previousOptOut = amplitude.options.optOut;
+      amplitude.setOptOut('invalid sessionTimeOut');
+      assert.equal(amplitude.options.optOut, previousOptOut);
     });
 
     it('should set optOut', function () {
@@ -4237,7 +4238,7 @@ describe('AmplitudeClient', function () {
       reset();
     });
 
-    it('EU serverZone should not set apiEndpoint to EU because of invaid useDynamicConfig value', function () {
+    it('EU serverZone should not set apiEndpoint to EU because of invalid useDynamicConfig value', function () {
       assert.equal(amplitude.options.apiEndpoint, constants.EVENT_LOG_URL);
       amplitude.init(apiKey, null, {
         serverZone: AmplitudeServerZone.EU,
@@ -4282,7 +4283,7 @@ describe('AmplitudeClient', function () {
     it('should set serverUrl with valid serverUrl input', function () {
       assert.equal(amplitude.options.apiEndpoint, constants.EVENT_LOG_URL);
       amplitude.init(apiKey);
-      amplitude.setServerUrl('api.eu.amplitude.com');
+      amplitude.setServerUrl(constants.EVENT_LOG_EU_URL);
       assert.equal(amplitude.options.apiEndpoint, constants.EVENT_LOG_EU_URL);
     });
   });
@@ -4293,40 +4294,33 @@ describe('AmplitudeClient', function () {
     });
 
     it('should not set serverZone with invalid serverZone value', function () {
-      assert.equal(amplitude.options.serverZone, 'US');
       amplitude.init(apiKey);
+      let previousServerZone = amplitude.options.serverZone;
       amplitude.setServerZone('invalid serverZone');
-      assert.equal(amplitude.options.serverZone, 'US');
+      assert.equal(amplitude.options.serverZone, previousServerZone);
     });
 
     it('should not set serverZone with invalid serverZoneBasedApi value', function () {
-      assert.equal(amplitude.options.serverZone, 'US');
       amplitude.init(apiKey);
-      amplitude.setServerZone('EU', 'invalid serverZoneBasedApi');
-      assert.equal(amplitude.options.serverZone, 'US');
+      assert.equal(amplitude.options.serverZone, AmplitudeServerZone.US);
+      amplitude.setServerZone(AmplitudeServerZone.EU, 'invalid serverZoneBasedApi');
+      assert.equal(amplitude.options.serverZone, AmplitudeServerZone.US);
     });
 
     it('should set serverZone to EU', function () {
-      assert.equal(amplitude.options.serverZone, 'US');
       amplitude.init(apiKey);
-      amplitude.setServerZone('EU');
-      assert.equal(amplitude.options.serverZone, 'EU');
+      assert.equal(amplitude.options.serverZone, AmplitudeServerZone.US);
+      amplitude.setServerZone(AmplitudeServerZone.EU);
+      assert.equal(amplitude.options.serverZone, AmplitudeServerZone.EU);
+      assert.equal(amplitude.options.apiEndpoint, constants.EVENT_LOG_EU_URL);
     });
 
-    it('should set serverZont to EU and serverUrl to EVENT_LOG_EU_URL with serverZoneBasedApi is true', function () {
-      assert.equal(amplitude.options.serverZone, 'US');
+    it('should set serverZone to EU and keep the default serverUrl with serverZoneBasedApi is false', function () {
       amplitude.init(apiKey);
-      amplitude.setServerZone('EU', true);
-      assert.equal(amplitude.options.serverZone, 'EU');
-      assert.equal(amplitude.options.apiEndpoint, 'api.eu.amplitude.com');
-    });
-
-    it('should set serverZont to EU and keep the default serverUrl with serverZoneBasedApi is false', function () {
-      assert.equal(amplitude.options.serverZone, 'US');
-      amplitude.init(apiKey);
-      amplitude.setServerZone('EU', false);
-      assert.equal(amplitude.options.serverZone, 'EU');
-      assert.equal(amplitude.options.apiEndpoint, 'api.amplitude.com');
+      assert.equal(amplitude.options.serverZone, AmplitudeServerZone.US);
+      amplitude.setServerZone(AmplitudeServerZone.EU, false);
+      assert.equal(amplitude.options.serverZone, AmplitudeServerZone.EU);
+      assert.equal(amplitude.options.apiEndpoint, constants.EVENT_LOG_URL);
     });
   });
 
@@ -4338,7 +4332,7 @@ describe('AmplitudeClient', function () {
     it('should get userId', function () {
       amplitude.init(apiKey, userId);
       let currentUserId = amplitude.getUserId();
-      assert.equal(amplitude.options.userId, currentUserId);
+      assert.equal(currentUserId, userId);
     });
 
     it('should get userId null', function () {
@@ -4371,9 +4365,10 @@ describe('AmplitudeClient', function () {
 
     it('should not set sessionTimeout with invalid input', function () {
       amplitude.init(apiKey);
+      let previousSessionTimeOut = amplitude.options.sessionTimeout;
       let newSessionTimeOut = 'invalid sessionTimeOut';
       amplitude.setMinTimeBetweenSessionsMillis(newSessionTimeOut);
-      assert.equal(amplitude.options.sessionTimeout, 30 * 60 * 1000);
+      assert.equal(amplitude.options.sessionTimeout, previousSessionTimeOut);
     });
 
     it('should set sessionTimeout', function () {
@@ -4416,13 +4411,15 @@ describe('AmplitudeClient', function () {
       clock.tick(sessionId);
       amplitude.init(apiKey);
       assert.equal(amplitude.getSessionId(), startTime);
+      assert.equal(amplitude.options.userId, null);
 
       amplitude.setUserId('test user', 'invalid startNewSession');
       assert.notEqual(amplitude.getSessionId(), new Date().getTime());
       assert.notEqual(amplitude.options.userId, 'test user');
+      assert.equal(amplitude.options.userId, null);
     });
 
-    it('should renew the session id with current timestemp', function () {
+    it('should set user id and renew the session id with current timestemp', function () {
       var amplitude = new AmplitudeClient();
       // set up initial session
       var sessionId = 1000;

--- a/test/amplitude-client.js
+++ b/test/amplitude-client.js
@@ -2840,6 +2840,24 @@ describe('AmplitudeClient', function () {
     });
   });
 
+  describe('setEventUploadThreshold', function () {
+    beforeEach(function () {
+      reset();
+    });
+
+    it('should not set eventUploadThreshold with invalid eventUploadThreshold value', function () {
+      amplitude.init(apiKey);
+      amplitude.setEventUploadThreshold('invalid eventUploadThreshold');
+      assert.equal(amplitude.options.eventUploadThreshold, 30);
+    });
+
+    it('should set eventUploadThreshold', function () {
+      amplitude.init(apiKey);
+      amplitude.setEventUploadThreshold(5);
+      assert.equal(amplitude.options.eventUploadThreshold, 5);
+    });
+  });
+
   describe('optOut', function () {
     beforeEach(function () {
       amplitude.init(apiKey);
@@ -2913,6 +2931,26 @@ describe('AmplitudeClient', function () {
       assert.lengthOf(events, 10);
       assert.deepEqual(events[0].user_properties, { $add: { test: 6 } });
       assert.deepEqual(events[9].user_properties, { $add: { test: 100 } });
+    });
+  });
+
+  describe('setOptOut', function () {
+    beforeEach(function () {
+      reset();
+    });
+
+    it('should not set optOut with invalid input', function () {
+      amplitude.init(apiKey);
+      let optOut = 'invalid sessionTimeOut';
+      amplitude.setOptOut(optOut);
+      assert.equal(amplitude.options.optOut, false);
+    });
+
+    it('should set optOut', function () {
+      amplitude.init(apiKey);
+      let optOut = true;
+      amplitude.setOptOut(optOut);
+      assert.equal(amplitude.options.optOut, true);
     });
   });
 
@@ -4147,6 +4185,206 @@ describe('AmplitudeClient', function () {
 
       assert.equal(name, 'test-library');
       assert.equal(version, '1.0-test');
+    });
+  });
+
+  describe('libraryName', function () {
+    beforeEach(function () {
+      reset();
+    });
+    it('should use the customize library name and default library version', function () {
+      amplitude.init(apiKey);
+      amplitude.setLibraryName('test-library');
+      amplitude.logEvent('Event Type');
+
+      const { name, version } = JSON.parse(queryString.parse(server.requests[0].requestBody).e)[0].library;
+
+      assert.equal(name, 'test-library');
+      assert.equal(version, amplitude.options.library.version);
+    });
+  });
+
+  describe('libraryVersion', function () {
+    beforeEach(function () {
+      reset();
+    });
+    it('should use the customize library version and default library name', function () {
+      amplitude.init(apiKey);
+      amplitude.setLibraryVersion('1.0-test');
+      amplitude.logEvent('Event Type');
+
+      const { name, version } = JSON.parse(queryString.parse(server.requests[0].requestBody).e)[0].library;
+
+      assert.equal(name, amplitude.options.library.name);
+      assert.equal(version, '1.0-test');
+    });
+  });
+
+  describe('setUseDynamicConfig', function () {
+    beforeEach(function () {
+      reset();
+    });
+
+    it('EU serverZone should not set apiEndpoint to EU because of invaid useDynamicConfig value', function () {
+      assert.equal(amplitude.options.apiEndpoint, constants.EVENT_LOG_URL);
+      amplitude.init(apiKey, null, {
+        serverZone: AmplitudeServerZone.EU,
+      });
+      amplitude.setUseDynamicConfig('invalid useDynamicConfig');
+      assert.equal(amplitude.options.apiEndpoint, constants.EVENT_LOG_URL);
+    });
+
+    it('should not set apiEndpoint to EU because because of dynamic configuration not enable', function () {
+      assert.equal(amplitude.options.apiEndpoint, constants.EVENT_LOG_URL);
+      amplitude.init(apiKey, null, {
+        serverZone: AmplitudeServerZone.EU,
+      });
+      amplitude.setUseDynamicConfig(false);
+      assert.equal(amplitude.options.apiEndpoint, constants.EVENT_LOG_URL);
+    });
+
+    it('EU serverZone with dynamic configuration enable should set apiEndpoint to EU', function () {
+      assert.equal(amplitude.options.apiEndpoint, constants.EVENT_LOG_URL);
+      amplitude.init(apiKey, null, {
+        serverZone: AmplitudeServerZone.EU,
+      });
+      amplitude.setUseDynamicConfig(true);
+      server.respondWith('{"ingestionEndpoint": "api.eu.amplitude.com"}');
+      server.respond();
+      assert.equal(amplitude.options.apiEndpoint, constants.EVENT_LOG_EU_URL);
+    });
+  });
+
+  describe('setServerUrl', function () {
+    beforeEach(function () {
+      reset();
+    });
+
+    it('should not set serverUrl because of invalid serverUrl input', function () {
+      assert.equal(amplitude.options.apiEndpoint, constants.EVENT_LOG_URL);
+      amplitude.init(apiKey);
+      amplitude.setServerUrl(100);
+      assert.equal(amplitude.options.apiEndpoint, constants.EVENT_LOG_URL);
+    });
+
+    it('should set serverUrl with valid serverUrl input', function () {
+      assert.equal(amplitude.options.apiEndpoint, constants.EVENT_LOG_URL);
+      amplitude.init(apiKey);
+      amplitude.setServerUrl('api.eu.amplitude.com');
+      assert.equal(amplitude.options.apiEndpoint, constants.EVENT_LOG_EU_URL);
+    });
+  });
+
+  describe('setServerZone', function () {
+    beforeEach(function () {
+      reset();
+    });
+
+    it('should not set serverZone with invalid serverZone value', function () {
+      assert.equal(amplitude.options.serverZone, 'US');
+      amplitude.init(apiKey);
+      amplitude.setServerZone('invalid serverZone');
+      assert.equal(amplitude.options.serverZone, 'US');
+    });
+
+    it('should not set serverZone with invalid serverZoneBasedApi value', function () {
+      assert.equal(amplitude.options.serverZone, 'US');
+      amplitude.init(apiKey);
+      amplitude.setServerZone('EU', 'invalid serverZoneBasedApi');
+      assert.equal(amplitude.options.serverZone, 'US');
+    });
+
+    it('should set serverZone to EU', function () {
+      assert.equal(amplitude.options.serverZone, 'US');
+      amplitude.init(apiKey);
+      amplitude.setServerZone('EU');
+      assert.equal(amplitude.options.serverZone, 'EU');
+    });
+
+    it('should set serverZont to EU and serverUrl to EVENT_LOG_EU_URL with serverZoneBasedApi is true', function () {
+      assert.equal(amplitude.options.serverZone, 'US');
+      amplitude.init(apiKey);
+      amplitude.setServerZone('EU', true);
+      assert.equal(amplitude.options.serverZone, 'EU');
+      assert.equal(amplitude.options.apiEndpoint, 'api.eu.amplitude.com');
+    });
+
+    it('should set serverZont to EU and keep the default serverUrl with serverZoneBasedApi is false', function () {
+      assert.equal(amplitude.options.serverZone, 'US');
+      amplitude.init(apiKey);
+      amplitude.setServerZone('EU', false);
+      assert.equal(amplitude.options.serverZone, 'EU');
+      assert.equal(amplitude.options.apiEndpoint, 'api.amplitude.com');
+    });
+  });
+
+  describe('getUserId', function () {
+    beforeEach(function () {
+      reset();
+    });
+
+    it('should get userId', function () {
+      amplitude.init(apiKey, userId);
+      let currentUserId = amplitude.getUserId();
+      assert.equal(amplitude.options.userId, currentUserId);
+    });
+
+    it('should get userId null', function () {
+      amplitude.init(apiKey);
+      assert.equal(amplitude.getUserId(), null);
+    });
+  });
+
+  describe('getDeviceId', function () {
+    beforeEach(function () {
+      reset();
+    });
+
+    it('should get a random deviceId', function () {
+      amplitude.init(apiKey, userId);
+      assert.lengthOf(amplitude.getDeviceId(), 22);
+    });
+
+    it('should get deviceId', function () {
+      const currentDeviceId = 'aa_bb_cc';
+      amplitude.init(apiKey, null, { deviceId: currentDeviceId });
+      assert.equal(amplitude.getDeviceId(), currentDeviceId);
+    });
+  });
+
+  describe('setMinTimeBetweenSessionsMillis', function () {
+    beforeEach(function () {
+      reset();
+    });
+
+    it('should not set sessionTimeout with invalid input', function () {
+      amplitude.init(apiKey);
+      let newSessionTimeOut = 'invalid sessionTimeOut';
+      amplitude.setMinTimeBetweenSessionsMillis(newSessionTimeOut);
+      assert.equal(amplitude.options.sessionTimeout, 30 * 60 * 1000);
+    });
+
+    it('should set sessionTimeout', function () {
+      amplitude.init(apiKey);
+      let newSessionTimeOut = 100;
+      amplitude.setMinTimeBetweenSessionsMillis(newSessionTimeOut);
+      assert.equal(amplitude.options.sessionTimeout, newSessionTimeOut);
+    });
+  });
+
+  describe('uploadEvents', function () {
+    beforeEach(function () {
+      reset();
+    });
+
+    it('should flush the events', function () {
+      amplitude.init(apiKey, null, { batchEvents: true, eventUploadThreshold: 30 });
+      amplitude.logEvent('Event Type');
+      assert.equal(amplitude._unsentEvents.length, 1);
+      amplitude.uploadEvents();
+      server.respondWith('success');
+      server.respond();
+      assert.equal(amplitude._unsentEvents.length, 0);
     });
   });
 });


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude JavaScript SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Expose more interfaces for flutter web support
The following are the API added in this pr. 
1. getDeviceId
2. getUserId
3. setMinTimeBetweenSessionsMillis
4. setEventUploadThreshold
5. setUseDynamicConfig
6. setServerZone
7. setServerUrl 

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-JavaScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
