### PR TITLE
fix: Add missing setLibrary API to snippet distribution

### DIFF
--- a/src/amplitude-snippet.js
+++ b/src/amplitude-snippet.js
@@ -79,6 +79,7 @@
     'logEventWithGroups',
     'setSessionId',
     'resetSessionId',
+    'setLibrary',
   ];
   function setUpProxy(instance) {
     function proxyMain(fn) {


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude JavaScript SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

<!-- What does the PR do? -->
Adds `setLibrary` to the list of stubbed snippet proxy methods (related to #443)

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-JavaScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
