### PR TITLE
fix: Add missing setTransport API to snippet

### DIFF
--- a/src/amplitude-snippet.js
+++ b/src/amplitude-snippet.js
@@ -80,6 +80,7 @@
     'setSessionId',
     'resetSessionId',
     'setLibrary',
+    'setTransport',
   ];
   function setUpProxy(instance) {
     function proxyMain(fn) {


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude JavaScript SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Adds missing setTransport API to snippet

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-JavaScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
