### PR TITLE
feat: add support for on new session start callback

### DIFF
--- a/src/options.js
+++ b/src/options.js
@@ -81,6 +81,7 @@ export default {
   optOut: false,
   onError: () => {},
   onExitPage: () => {},
+  onNewSessionStart: () => {},
   plan: {
     branch: '',
     source: '',

--- a/test/amplitude-client.js
+++ b/test/amplitude-client.js
@@ -125,7 +125,44 @@ describe('AmplitudeClient', function () {
       });
 
       amplitude.init(apiKey);
-      assert.lengthOf(amplitude._onInit, 0);
+      assert.lengthOf(amplitude._onInitCallbacks, 0);
+    });
+
+    it('should invoke onNewSessionStart callbacks on new session passed through init()', function () {
+      const callback = sinon.spy();
+      const amplitude2 = new AmplitudeClient();
+      amplitude2.init(apiKey, undefined, {
+        onNewSessionStart: callback,
+      });
+      assert.lengthOf(amplitude2._onNewSessionStartCallbacks, 1);
+      assert.ok(callback.calledOnce);
+    });
+
+    it('should invoke onNewSessionStart callbacks on new session pased through onNewSessionStart()', function () {
+      const callback = sinon.spy();
+      const amplitude2 = new AmplitudeClient();
+      amplitude2.onNewSessionStart(callback);
+      amplitude2.init(apiKey);
+      assert.lengthOf(amplitude2._onNewSessionStartCallbacks, 1);
+      assert.ok(callback.calledOnce);
+    });
+
+    it('should pass the amplitude instance to onNewSessionStart callbacks', () => {
+      const callback = sinon.spy();
+      const amplitude2 = new AmplitudeClient();
+      amplitude2.onNewSessionStart(callback);
+      amplitude2.init(apiKey);
+      assert.isTrue(callback.calledWith(amplitude2));
+    });
+
+    it('should include a session id on onNewSessionStart callback', () => {
+      let sessionId = null;
+      const amplitude2 = new AmplitudeClient();
+      amplitude2.onNewSessionStart((a) => {
+        sessionId = a.getSessionId();
+      });
+      amplitude2.init(apiKey);
+      assert.isNumber(sessionId);
     });
 
     it('fails on invalid apiKeys', function () {


### PR DESCRIPTION
### Summary

This PR adds support for on new session start callback. Callback functions can be registered to `onNewSessionStart` event using the following ways:

#### Method 1
```javascript
amplitude.getInstance().onNewSessionStart(() => {
  console.log('new session - method 1');
});
```
#### Method 2
```javascript
amplitude.init('API_KEY', USER_ID, {
  onNewSessionStart: () => {
    console.log('new session - method 2')
  },
});
```

### Testing
* Unit tests are passing
* Manually tested by executing the following below:
```
// cookies are deleted and page is refreshed

// register onInit callback
> amplitude.getInstance().onInit(() => console.log('init'))

// register session callback 1
> amplitude.getInstance().onNewSessionStart(() => console.log('session - method 1'))

// register session callback 2
// invoke init - runs registered callback fns
> amplitude.init('a2dbce0e18dfe5f8e74493843ff5c053', undefined, { onNewSessionStart: () => console.log('session - method 2') })
init
session - method 1
session - method 2

// invoke init - does not run registered callbacks fns
// init callback is already reset
// session callbacks are not called because no new session is created
> amplitude.init('a2dbce0e18dfe5f8e74493843ff5c053')

// invoke setUserId and create new session  - runs registered callback fns
> amplitude.getInstance().setUserId('asdf', true)
session - method 1
session - method 2
```

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-JavaScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?  None

Closes https://github.com/amplitude/Amplitude-JavaScript/issues/429