### PR TITLE
fix: add public method onNewSessionStart to snippet

### DIFF
--- a/src/amplitude-snippet.js
+++ b/src/amplitude-snippet.js
@@ -75,6 +75,7 @@
     'regenerateDeviceId',
     'groupIdentify',
     'onInit',
+    'onNewSessionStart',
     'logEventWithTimestamp',
     'logEventWithGroups',
     'setSessionId',


### PR DESCRIPTION
### Summary

PR https://github.com/amplitude/Amplitude-JavaScript/pull/455 adds a new public method. This public method needs to be added to the snippet to allow the method to be called while amplitude.js script is being loaded.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-JavaScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change? None
