### PR TITLE
fix: make @babel/runtime production dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@amplitude/ua-parser-js": "0.7.26",
     "@amplitude/utils": "^1.0.5",
+    "@babel/runtime": "^7.3.4",
     "blueimp-md5": "^2.10.0",
     "query-string": "5"
   },
@@ -27,7 +28,6 @@
     "@babel/plugin-proposal-object-rest-spread": "^7.3.4",
     "@babel/plugin-transform-runtime": "^7.3.4",
     "@babel/preset-env": "^7.3.4",
-    "@babel/runtime": "^7.3.4",
     "@semantic-release/changelog": "^5.0.1",
     "@semantic-release/exec": "^5.0.0",
     "@semantic-release/git": "^9.0.0",


### PR DESCRIPTION
### Summary

In the past, a [change](https://github.com/amplitude/Amplitude-JavaScript/commit/313533ded6bb69a963a6a45424efae3f424641f1) was introduced that moved [@babel/runtime](https://babeljs.io/docs/en/babel-runtime) as dev dependency. The said change was included in [v5.3.1](https://www.npmjs.com/package/amplitude-js/v/5.3.1) and is in effect until latest [v8.13.0](https://www.npmjs.com/package/amplitude-js/v/8.13.0).

As mentioned in @babel/runtime [docs](https://babeljs.io/docs/en/babel-runtime#usage):

> This is meant to be used as a runtime dependency along with the Babel plugin @babel/plugin-transform-runtime. Please check out the documentation in that package for usage.

This PR fixes https://github.com/amplitude/Amplitude-JavaScript/issues/451

### Testing

Using [adz/amplitude-esbuild](https://github.com/adz/amplitude-esbuild/tree/main) as playground, I was reproduce the issue in v8.13.0 and v5.3.1; but not with v5.3.0 and this PR as expected.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-JavaScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change? No
