### PR TITLE
build: fix build for amplitude-segment-snippet.min.js

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ $(SNIPPET_OUT): $(SRC) $(SNIPPET)
 	@$(MINIFY) $(SNIPPET) -m -b max-line-len=80,beautify=false | awk 'NF' > $(SNIPPET_OUT)
 
 $(SEGMENT_SNIPPET_OUT): $(SRC) $(SNIPPET)
-	@grep -Ev "\ba?s\b" $(SNIPPET) | $(MINIFY) -m -b max-line-len=80,beautify=false - \
+	@sed -n '/createElement/,/insertBefore/!p' $(SNIPPET) | $(MINIFY) -m -b max-line-len=80,beautify=false - \
 		| awk 'NF' > $(SEGMENT_SNIPPET_OUT)
 
 #


### PR DESCRIPTION
### Summary

This change includes a fix to the build step that generates `amplitude-segment-snippet.min.js`.

Currently, the build steps fails on minify, after `grep` pipes code to minify that contains syntax errors. The syntax error stems from to an incorrect pattern used in `grep`. The pattern was previously working with unstyled code until prettier was introduced in this [commit](https://github.com/amplitude/Amplitude-JavaScript/commit/79585d5b84d814932783c97bae851ac361b548a5#diff-8225cfb965ecb3a71b11e26c0fde0e40e7d74db041de68803130320053d891edR17-R21).

After prettier was introduced, the following line in `src/amplitude-snippet.js`:

```js
as.onload = function() {if(!window.amplitude.runQueuedFunctions) {console.log('[Amplitude] Error: could not load SDK');}};
```

turned into:

```js
as.onload = function () {
  if (!window.amplitude.runQueuedFunctions) {
    console.log('[Amplitude] Error: could not load SDK');
  }
};
```

where the pattern does not work with. This leads to code containing syntax errors getting piped to minify and ultimately causing it to fail. The output is an empty file named `amplitude-segment-snippet.min.js`.

In addition, with the output file being empty, it breaks the release workflow for `@semantic-release/github` in the step where it publishes the file that matches this [blob](https://github.com/amplitude/Amplitude-JavaScript/blob/74fed0a60e724d9fb2786b5bac3b0867546880f5/release.config.js#L23). This publish step validates that the file is not empty. The empty`amplitude-segment-snippet.min.js` violates the rule leading to a failed release workflow.

The change assumes that `amplitude-segment-snippet.min.js` is still relevant and needs to be kept. If the assumption is not true, we can alternatively remove the build step for this file.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-JavaScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
