### PR TITLE
docs: replace links pointing to master with links pointing to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@ A JavaScript SDK for tracking events and revenue to [Amplitude](https://www.ampl
 
 ## Installation and Quick Start
 * For using the SDK, please visit our :100:[Developer Center](https://developers.amplitude.com/docs/javascript).
-* For developing the SDK, please visit our [CONTRIBUTING.md](https://github.com/amplitude/Amplitude-JavaScript/blob/master/CONTRIBUTING.md).
+* For developing the SDK, please visit our [CONTRIBUTING.md](https://github.com/amplitude/Amplitude-JavaScript/blob/main/CONTRIBUTING.md).
 
 ## Demo Pages
-* A [demo page](https://github.com/amplitude/Amplitude-JavaScript/blob/master/test/browser/amplitudejs.html) showing a simple integration on a web page.
-* A [demo page](https://github.com/amplitude/Amplitude-JavaScript/blob/master/test/browser/amplitudejs-requirejs.html) showing an integration using RequireJS.
+* A [demo page](https://github.com/amplitude/Amplitude-JavaScript/blob/main/test/browser/amplitudejs.html) showing a simple integration on a web page.
+* A [demo page](https://github.com/amplitude/Amplitude-JavaScript/blob/main/test/browser/amplitudejs-requirejs.html) showing an integration using RequireJS.
 * A [demo page](https://github.com/amplitude/GTM-Web-Demo) demonstrating a potential integration with Google Tag Manager.
 
 


### PR DESCRIPTION
### Summary

`README.md` contains links pointing to `master` branch. The said branch is no longer maintained and contains outdated information. With `README.md` being the one of the first docs developers will go through, it is important that it contains up-to-date information about this repository.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-JavaScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change? No
