### PR TITLE
build: fix amplitude sdk version in amplitude-snippet.min.js output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ version: package.json
 #
 # Target for updating readme.
 
-README.md: $(SNIPPET_OUT) version
+README.md: version $(SNIPPET_OUT)
 	node scripts/readme
 
 #


### PR DESCRIPTION
### Summary

The generated snippet files published to GitHub packages are using the prior release version. Though GitHub packages isn't a main distribution channel for Amplitude, accuracy of build files are very important. This PR fixes the build process to update versions first in targeted files before generating the snippet files.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-JavaScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
