### PR TITLE
fix: Add missing worker storage length for clear method

### DIFF
--- a/src/worker-storage.js
+++ b/src/worker-storage.js
@@ -30,5 +30,6 @@ export default class WorkerStorage {
 
   clear() {
     this.map.clear();
+    this.length = 0;
   }
 }

--- a/test/worker-storage.js
+++ b/test/worker-storage.js
@@ -15,6 +15,7 @@ describe('WorkerStorage', function () {
       workerStorage.setItem('0', 'zero');
       workerStorage.setItem('1', 'one');
       assert.isTrue(workerStorage.key(1) === 'one');
+      assert.isTrue(workerStorage.length === 2);
     });
   });
 
@@ -23,6 +24,7 @@ describe('WorkerStorage', function () {
       const workerStorage = new WorkerStorage();
       workerStorage.setItem('0', 'zero');
       assert.isTrue(workerStorage.getItem('0') === 'zero');
+      assert.isTrue(workerStorage.length === 1);
     });
   });
 
@@ -32,6 +34,7 @@ describe('WorkerStorage', function () {
       workerStorage.setItem('0', 'zero');
       workerStorage.removeItem('0');
       assert.isTrue(workerStorage.getItem('0') === undefined);
+      assert.isTrue(workerStorage.length === 0);
     });
   });
 
@@ -43,6 +46,7 @@ describe('WorkerStorage', function () {
       workerStorage.clear();
       assert.isTrue(workerStorage.getItem('0') === undefined);
       assert.isTrue(workerStorage.getItem('1') === undefined);
+      assert.isTrue(workerStorage.length === 0);
     });
   });
 });


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude JavaScript SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

<!-- What does the PR do? -->
This PR is to reset worker storage length when calling `clear()` function.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-JavaScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
