### PR TITLE
build: Make snippet instructions available to public

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -15,8 +15,8 @@ module.exports = {
     }],
     "@semantic-release/npm",
     ["@semantic-release/exec", {
-      "prepareCmd": "make release",
-      "publishCmd": "node scripts/create-snippet-instructions.js && python scripts/deploy_s3.py --version ${nextRelease.version}",
+      "prepareCmd": "make release && node scripts/create-snippet-instructions.js",
+      "publishCmd": "python scripts/deploy_s3.py --version ${nextRelease.version}",
       "failCmd": "npm unpublish amplitude-js@${nextRelease.version}"
     }],
     ["@semantic-release/github", {


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude JavaScript SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Re-orders release.config.js steps so that `create-snippet-instructions.js` will run before NPM publishes

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-JavaScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no --> NO
