### PR TITLE
feat: allow cors header to be excluded from request headers

### DIFF
--- a/src/xhr.js
+++ b/src/xhr.js
@@ -10,8 +10,13 @@ var Request = function (url, data, headers) {
   this.headers = headers;
 };
 
+const CORS_HEADER = 'Cross-Origin-Resource-Policy';
+
 function setHeaders(xhr, headers) {
   for (const header in headers) {
+    if (header === CORS_HEADER && !headers[header]) {
+      continue;
+    }
     xhr.setRequestHeader(header, headers[header]);
   }
 }

--- a/test/amplitude-client.js
+++ b/test/amplitude-client.js
@@ -1690,6 +1690,42 @@ describe('AmplitudeClient', function () {
       assert.equal(server.requests[0].requestHeaders['Content-Type'], 'application/json;charset=utf-8');
     });
 
+    it('should send request with no cors header when passed an empty string', function () {
+      amplitude.init(apiKey, null, {
+        headers: { 'Cross-Origin-Resource-Policy': '' },
+      });
+      amplitude.logEvent('Event Type 1');
+      assert.lengthOf(server.requests, 1);
+      assert.notExists(server.requests[0].requestHeaders['Cross-Origin-Resource-Policy']);
+    });
+
+    it('should send request with no cors header when passed undefined', function () {
+      amplitude.init(apiKey, null, {
+        headers: { 'Cross-Origin-Resource-Policy': undefined },
+      });
+      amplitude.logEvent('Event Type 1');
+      assert.lengthOf(server.requests, 1);
+      assert.notExists(server.requests[0].requestHeaders['Cross-Origin-Resource-Policy']);
+    });
+
+    it('should send request with no cors header when passed null', function () {
+      amplitude.init(apiKey, null, {
+        headers: { 'Cross-Origin-Resource-Policy': null },
+      });
+      amplitude.logEvent('Event Type 1');
+      assert.lengthOf(server.requests, 1);
+      assert.notExists(server.requests[0].requestHeaders['Cross-Origin-Resource-Policy']);
+    });
+
+    it('should send request with custom cors header', function () {
+      amplitude.init(apiKey, null, {
+        headers: { 'Cross-Origin-Resource-Policy': 'same-site' },
+      });
+      amplitude.logEvent('Event Type 1');
+      assert.lengthOf(server.requests, 1);
+      assert.equal(server.requests[0].requestHeaders['Cross-Origin-Resource-Policy'], 'same-site');
+    });
+
     it('should send https request', function () {
       amplitude.options.forceHttps = true;
       amplitude.logEvent('Event Type 1');
@@ -1697,6 +1733,7 @@ describe('AmplitudeClient', function () {
       assert.equal(server.requests[0].url, 'https://api.amplitude.com');
       assert.equal(server.requests[0].method, 'POST');
       assert.equal(server.requests[0].async, true);
+      assert.equal(server.requests[0].requestHeaders['Cross-Origin-Resource-Policy'], 'cross-origin');
     });
 
     it('should send https request by configuration', function () {


### PR DESCRIPTION
### Summary

A change was introduce in v8.7.0 that enforces cors in request headers by default. There isn't a way to remove it for users who do not need it. This change allows cors to be removed from request headers by passing `''`, `null`, `undefined` to `config.headers['Cross-Origin-Resource-Policy']` on init.

##### CODE SAMPLE

```js
amplitude.getInstance().init(<API_KEY>, <USER_ID>, {
  headers: {
    'Cross-Origin-Resource-Policy': undefined,
  }
});
```

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-JavaScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
