### PR TITLE
docs: fix link to user group docs

### DIFF
--- a/src/amplitude-client.js
+++ b/src/amplitude-client.js
@@ -939,7 +939,7 @@ AmplitudeClient.prototype.setUserId = function setUserId(userId, startNewSession
  * You can also call setGroup multiple times with different groupTypes to track multiple types of groups (up to 5 per app).
  *
  * Note: this will also set groupType: groupName as a user property.
- * See the [advanced topics article](https://developers.amplitude.com/docs/setting-user-groups) for more information.
+ * See the [advanced topics article](https://developers.amplitude.com/docs/javascript#user-groups) for more information.
  * @public
  * @param {string} groupType - the group type (ex: orgId)
  * @param {string|list} groupName - the name of the group (ex: 15), or a list of names of the groups
@@ -1543,7 +1543,7 @@ AmplitudeClient.prototype.logEventWithTimestamp = function logEvent(
  * Note: the group(s) set only apply for the specific event type being logged and does not persist on the user
  * (unless you explicitly set it with setGroup).
  *
- * See the [advanced topics article](https://developers.amplitude.com/docs/setting-user-groups) for more information.
+ * See the [advanced topics article](https://developers.amplitude.com/docs/javascript#user-groups) for more information
  * about groups and Count by Distinct on the Amplitude platform.
  * @public
  * @param {string} eventType - name of event

--- a/src/amplitude.js
+++ b/src/amplitude.js
@@ -172,7 +172,7 @@ if (BUILD_COMPAT_2_0) {
    * groupName can be a string or an array of strings to indicate a user in multiple gruups.
    * You can also call setGroup multiple times with different groupTypes to track multiple types of groups (up to 5 per app).
    * Note: this will also set groupType: groupName as a user property.
-   * See the [advanced topics article](https://developers.amplitude.com/docs/setting-user-groups) for more information.
+   * See the [advanced topics article](https://developers.amplitude.com/docs/javascript#user-groups) for more information.
    * @public
    * @param {string} groupType - the group type (ex: orgId)
    * @param {string|list} groupName - the name of the group (ex: 15), or a list of names of the groups
@@ -299,7 +299,7 @@ if (BUILD_COMPAT_2_0) {
    * Note: the group(s) set only apply for the specific event type being logged and does not persist on the user
    * (unless you explicitly set it with setGroup).
    *
-   * See the [advanced topics article](https://developers.amplitude.com/docs/setting-user-groups) for more information.
+   * See the [advanced topics article](https://developers.amplitude.com/docs/javascript#user-groups) for more information
    * about groups and Count by Distinct on the Amplitude platform.
    * @public
    * @param {string} eventType - name of event


### PR DESCRIPTION
### Summary

Fixes jsdoc for `setGroup()` and `logEventWithGroups()` to replace old url to new url

Old link: https://developers.amplitude.com/docs/setting-user-groups

New link: https://developers.amplitude.com/docs/javascript#user-groups

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-JavaScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?: No
