### PR TITLE
fix: use uuid for test cookie value

### DIFF
--- a/src/base-cookie.js
+++ b/src/base-cookie.js
@@ -1,7 +1,6 @@
 import Constants from './constants';
 import base64Id from './base64Id';
 import utils from './utils';
-import uuid from './uuid';
 
 const get = (name) => {
   try {
@@ -101,7 +100,7 @@ const areCookiesEnabled = (opts = {}) => {
   }
   let _areCookiesEnabled = false;
   try {
-    const uid = uuid();
+    const uid = String(Date.now());
     set(cookieName, uid, opts);
     utils.log.info(`Testing if cookies available`);
     _areCookiesEnabled = get(cookieName + '=') === uid;

--- a/src/base-cookie.js
+++ b/src/base-cookie.js
@@ -1,6 +1,7 @@
 import Constants from './constants';
 import base64Id from './base64Id';
 import utils from './utils';
+import uuid from './uuid';
 
 const get = (name) => {
   try {
@@ -100,7 +101,7 @@ const areCookiesEnabled = (opts = {}) => {
   }
   let _areCookiesEnabled = false;
   try {
-    const uid = String(new Date());
+    const uid = uuid();
     set(cookieName, uid, opts);
     utils.log.info(`Testing if cookies available`);
     _areCookiesEnabled = get(cookieName + '=') === uid;


### PR DESCRIPTION
### Summary

Fixes https://github.com/amplitude/Amplitude-JavaScript/issues/481

`areCookiesEnabled()` creates a cookie that gets rejected by firewalls due to some special characters included in TZ names. It should be safe to replace this cookie value with virtually anything (w/o special characters) since this is short lived and only used to determine if cookies are enabled. I decided to change it to a random-ish value, to avoid potential conflict.

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-JavaScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
