### PR TITLE
fix: assign domain after cookie storage options are given

### DIFF
--- a/src/amplitude-client.js
+++ b/src/amplitude-client.js
@@ -126,7 +126,6 @@ AmplitudeClient.prototype.init = function init(apiKey, opt_userId, opt_config, o
       secure: this.options.secureCookie,
       sameSite: this.options.sameSiteCookie,
     });
-    this.options.domain = this.cookieStorage.options().domain;
 
     this._metadataStorage = new MetadataStorage({
       storageKey: this._cookieName,
@@ -147,6 +146,8 @@ AmplitudeClient.prototype.init = function init(apiKey, opt_userId, opt_config, o
       this._deferInitialization(apiKey, opt_userId, opt_config, opt_callback);
       return;
     }
+
+    this.options.domain = this.cookieStorage.options().domain;
 
     if (type(this.options.logLevel) === 'string') {
       utils.setLogLevel(this.options.logLevel);

--- a/src/amplitude-client.js
+++ b/src/amplitude-client.js
@@ -126,6 +126,7 @@ AmplitudeClient.prototype.init = function init(apiKey, opt_userId, opt_config, o
       secure: this.options.secureCookie,
       sameSite: this.options.sameSiteCookie,
     });
+    this.options.domain = this.cookieStorage.options().domain;
 
     this._metadataStorage = new MetadataStorage({
       storageKey: this._cookieName,
@@ -141,7 +142,6 @@ AmplitudeClient.prototype.init = function init(apiKey, opt_userId, opt_config, o
     const hasNewCookie = !!this._metadataStorage.load();
     this._useOldCookie = !hasNewCookie && hasOldCookie && !this.options.cookieForceUpgrade;
     const hasCookie = hasNewCookie || hasOldCookie;
-    this.options.domain = this.cookieStorage.options().domain;
 
     if (this.options.deferInitialization && !hasCookie) {
       this._deferInitialization(apiKey, opt_userId, opt_config, opt_callback);


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude JavaScript SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

<!-- What does the PR do? -->
Because this domain value is needed while initializing metadata storage, assign `options.domain` after cookie storage options are given. 

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-JavaScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->No
