### PR TITLE
fix: replace String.prototype.includes with String.prototype.indexOf

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -102,7 +102,7 @@ const validateDeviceId = function validateDeviceId(deviceId) {
   if (!validateInput(deviceId, 'deviceId', 'string')) {
     return false;
   }
-  if (deviceId.includes('.')) {
+  if (deviceId.indexOf('.') >= 0) {
     log.error(`Device IDs may not contain '.' characters. Value will be ignored: "${deviceId}"`);
     return false;
   }


### PR DESCRIPTION
### Summary

IE does not support `String.prototype.includes` therefore replacing with `String.prototype.indexOf`

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-JavaScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
