### PR TITLE
fix: fix perms for github token in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,9 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     needs: [authorize]
+    permissions:
+      id-token: write
+      contents: read
     env:
       GIT_AUTHOR_NAME: amplitude-sdk-bot
       GIT_AUTHOR_EMAIL: amplitude-sdk-bot@users.noreply.github.com


### PR DESCRIPTION
### Summary

Fix perms for github token used in release workflow. This allows github token to read tokens needed to communicate with aws.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-JavaScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?: No
