### PR TITLE
fix: fix release work flow perms to include write access to contents

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
     needs: [authorize]
     permissions:
       id-token: write
-      contents: read
+      contents: write
     env:
       GIT_AUTHOR_NAME: amplitude-sdk-bot
       GIT_AUTHOR_EMAIL: amplitude-sdk-bot@users.noreply.github.com


### PR DESCRIPTION
### Summary

fix release work flow perms to include write access to contents. this allows the github token to push tags to github

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-JavaScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
