### PR TITLE
fix: fix s3 upload script to use iam role

### DIFF
--- a/scripts/deploy_s3.py
+++ b/scripts/deploy_s3.py
@@ -40,8 +40,6 @@ def main():
                         help='Version to deploy')
     args = parser.parse_args()
     s3 = Session(
-        aws_access_key_id=os.environ.get('AWS_ACCESS_KEY_ID'),
-        aws_secret_access_key=os.environ.get('AWS_SECRET_ACCESS_KEY'),
         region_name=os.environ.get('AWS_REGION'),
     ).resource('s3')
     bucket = s3.Bucket(os.environ.get('S3_BUCKET_NAME'))

--- a/scripts/deploy_s3.py
+++ b/scripts/deploy_s3.py
@@ -39,9 +39,7 @@ def main():
     parser.add_argument('--version', '-v', required=True,
                         help='Version to deploy')
     args = parser.parse_args()
-    s3 = Session(
-        region_name=os.environ.get('AWS_REGION'),
-    ).resource('s3')
+    s3 = Session().resource('s3')
     bucket = s3.Bucket(os.environ.get('S3_BUCKET_NAME'))
 
     files = [


### PR DESCRIPTION
### Summary

Fix s3 script to use **default** aws config associated with an iam role. Access key and secret access key are no longer available to use. We use `aws-actions/configure-aws-credentials@v1` to auth with an iam role. Github actions will assume `github-actions-role` and perform api actions the role has been granted to.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-JavaScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
