### PR TITLE
feat: enable the ability to overwrite the referrer

### DIFF
--- a/src/amplitude-client.js
+++ b/src/amplitude-client.js
@@ -789,7 +789,10 @@ var _sendParamsReferrerUserProperties = function _sendParamsReferrerUserProperti
  * @private
  */
 AmplitudeClient.prototype._getReferrer = function _getReferrer() {
-  return typeof document !== 'undefined' ? document.referrer : '';
+  const urlRefer = this._getReferrerFromUrlParam(this._getUrlParams());
+
+  if (urlRefer) return urlRefer;
+  else typeof document !== 'undefined' ? document.referrer : '';
 };
 
 /**
@@ -833,6 +836,14 @@ AmplitudeClient.prototype._saveFbclid = function _saveFbclid(urlParams) {
  */
 AmplitudeClient.prototype._getDeviceIdFromUrlParam = function _getDeviceIdFromUrlParam(urlParams) {
   return utils.getQueryParam(Constants.AMP_DEVICE_ID_PARAM, urlParams);
+};
+
+/**
+ * Try to fetch referrer from url params.
+ * @private
+ */
+AmplitudeClient.prototype._getReferrerFromUrlParam = function _getReferrerFromUrlParam(urlParams) {
+  return utils.getQueryParam(Constants.AMP_REFERRER_PARAM, urlParams);
 };
 
 /**

--- a/src/amplitude-client.js
+++ b/src/amplitude-client.js
@@ -792,7 +792,7 @@ AmplitudeClient.prototype._getReferrer = function _getReferrer() {
   const urlRefer = this._getReferrerFromUrlParam(this._getUrlParams());
 
   if (urlRefer) return urlRefer;
-  else typeof document !== 'undefined' ? document.referrer : '';
+  else return typeof document !== 'undefined' ? document.referrer : '';
 };
 
 /**

--- a/src/constants.js
+++ b/src/constants.js
@@ -50,6 +50,7 @@ export default {
   REVENUE_REVENUE_TYPE: '$revenueType',
 
   AMP_DEVICE_ID_PARAM: 'amp_device_id', // url param
+  AMP_REFERRER_PARAM: 'amp_referrer', // url param for overwriting the document.refer
 
   REFERRER: 'referrer',
 


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude JavaScript SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary
https://discourse.amplitude.com/t/incorrectly-logged-referrer-due-to-cookie-control/7164
This pr for providing the ability to let customers overwrite the referrer info.
The use case:
Customer need to defer the initialization with the cookie control. Before accepting cookies, the users might redirect to other pages. And the `document.referrer` will be set to the last page they were on. So they will lose the original referrer info after enabling tracking.
This pr enable customer using this SDK to pass an overwrite value through url parameter in order to overwrite the referrer info.


<!-- What does the PR do? -->

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-JavaScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
