### PR TITLE
feat: add ingestion_metadata field

### DIFF
--- a/src/amplitude-client.js
+++ b/src/amplitude-client.js
@@ -1430,6 +1430,13 @@ AmplitudeClient.prototype._logEvent = function _logEvent(
       };
     }
 
+    if (_isIngestionMetadataSet(this)) {
+      event.ingestion_metadata = {
+        source_name: this.options.ingestionMetadata.sourceName || undefined,
+        source_version: this.options.ingestionMetadata.sourceVersion || undefined,
+      };
+    }
+
     if (eventType === Constants.IDENTIFY_EVENT || eventType === Constants.GROUP_IDENTIFY_EVENT) {
       this._unsentIdentifys.push({ event, callback, errorCallback });
       this._limitEventsQueued(this._unsentIdentifys);
@@ -1466,6 +1473,13 @@ const _isObservePlanSet = function _isObservePlanSet(scope) {
       scope.options.plan.branch ||
       scope.options.plan.version ||
       scope.options.plan.versionId)
+  );
+};
+
+const _isIngestionMetadataSet = function _isIngestionMetadataSet(scope) {
+  return (
+    scope.options.ingestionMetadata &&
+    (scope.options.ingestionMetadata.sourceName || scope.options.ingestionMetadata.sourceVersion)
   );
 };
 

--- a/src/options.js
+++ b/src/options.js
@@ -24,6 +24,9 @@ import { version as libraryVersion } from '../package.json';
  * @property {boolean} [includeGclid=`false`] -  If `true`, captures the gclid URL parameter as well as the user's initial_gclid via a setOnce operation.
  * @property {boolean} [includeReferrer=`false`] -  If `true`, captures the referrer and referring_domain for each session, as well as the user's initial_referrer and initial_referring_domain via a setOnce operation.
  * @property {boolean} [includeUtm=`false`] -  If `true`, finds UTM parameters in the query string or the _utmz cookie, parses, and includes them as user properties on all events uploaded. This also captures initial UTM parameters for each session via a setOnce operation.
+ * @property {Object} [ingestionMetadata] Ingestion metadata
+ * @property {string} [ingestionMetadata.sourceName] source name in ingestion metadata, e.g. "ampli"
+ * @property {string} [ingestionMetadata.sourceVersion] source version in ingestion metadata, e.g. "1.0.0"
  * @property {string} [language=The language determined by the browser] -  Custom language to set.
  * @property {Object} [library=`{ name: 'amplitude-js', version: packageJsonVersion }`] -  Values for the library version
  * @property {string} [logLevel=`WARN`] -  Level of logs to be printed in the developer console. Valid values are 'DISABLE', 'ERROR', 'WARN', 'INFO'. To learn more about the different options, see below.
@@ -74,6 +77,10 @@ export default {
   includeGclid: false,
   includeReferrer: false,
   includeUtm: false,
+  ingestionMetadata: {
+    sourceName: '',
+    sourceVersion: '',
+  },
   language: language.getLanguage(),
   library: {
     name: 'amplitude-js',

--- a/test/amplitude-client.js
+++ b/test/amplitude-client.js
@@ -908,6 +908,17 @@ describe('AmplitudeClient', function () {
       assert.deepEqual(amplitude.options.plan, plan);
     });
 
+    it('should set ingestion metadata options', function () {
+      const amplitude = new AmplitudeClient('ingestion metadata');
+      const ingestionMetadata = {
+        sourceName: 'ampli',
+        sourceVersion: '1.0.0',
+      };
+      amplitude.init(apiKey, null, { ingestionMetadata: ingestionMetadata });
+
+      assert.deepEqual(amplitude.options.ingestionMetadata, ingestionMetadata);
+    });
+
     it('should set sessionId from config', () => {
       const amplitude = new AmplitudeClient();
       amplitude.init(apiKey, null, { sessionId: 123 });
@@ -4570,6 +4581,38 @@ describe('AmplitudeClient', function () {
 
       amplitude.logEvent('testEvent1');
       assert.equal(amplitude._unsentEvents[0].event.partner_id, null);
+    });
+  });
+
+  describe('ingestionMetadata Support', function () {
+    beforeEach(function () {
+      // reset ingestionMetadata
+      amplitude.options.ingestionMetadata = {
+        sourceName: '',
+        sourceVersion: '',
+      };
+      reset();
+    });
+
+    it('should include ingestion_metadata', function () {
+      const ingestionMetadata = {
+        sourceName: 'ampli',
+        sourceVersion: '1.0.0',
+      };
+      amplitude.init(apiKey, null, { batchEvents: true, ingestionMetadata: ingestionMetadata });
+
+      amplitude.logEvent('testEvent1');
+      assert.deepEqual(amplitude._unsentEvents[0].event.ingestion_metadata, {
+        source_name: 'ampli',
+        source_version: '1.0.0',
+      });
+    });
+
+    it('should set ingestion_metadata default null', function () {
+      amplitude.init(apiKey, null, { batchEvents: true });
+
+      amplitude.logEvent('testEvent1');
+      assert.equal(amplitude._unsentEvents[0].event.ingestion_metadata, null);
     });
   });
 });


### PR DESCRIPTION
### Summary
- feat: add ingestion_metadata field

Add this option in the configuration, which can be used in the library wrapper/code generation/dynamic loading cases, for setting the `ingestion_metadata` information.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-JavaScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
