### PR TITLE
fix: nested object in options are shared across multiple instances

### DIFF
--- a/src/amplitude-client.js
+++ b/src/amplitude-client.js
@@ -42,6 +42,7 @@ var AmplitudeClient = function AmplitudeClient(instanceName) {
   this.options = {
     ...DEFAULT_OPTIONS,
     headers: { ...DEFAULT_OPTIONS.headers },
+    ingestionMetadata: { ...DEFAULT_OPTIONS.ingestionMetadata },
     library: { ...DEFAULT_OPTIONS.library },
     plan: { ...DEFAULT_OPTIONS.plan },
     trackingOptions: { ...DEFAULT_OPTIONS.trackingOptions },

--- a/src/amplitude-client.js
+++ b/src/amplitude-client.js
@@ -39,7 +39,13 @@ var AmplitudeClient = function AmplitudeClient(instanceName) {
   this._instanceName = utils.isEmptyString(instanceName) ? Constants.DEFAULT_INSTANCE : instanceName.toLowerCase();
   this._unsentEvents = [];
   this._unsentIdentifys = [];
-  this.options = { ...DEFAULT_OPTIONS, trackingOptions: { ...DEFAULT_OPTIONS.trackingOptions } };
+  this.options = {
+    ...DEFAULT_OPTIONS,
+    headers: { ...DEFAULT_OPTIONS.headers },
+    library: { ...DEFAULT_OPTIONS.library },
+    plan: { ...DEFAULT_OPTIONS.plan },
+    trackingOptions: { ...DEFAULT_OPTIONS.trackingOptions },
+  };
   this.cookieStorage = new cookieStorage().getStorage();
   this._q = []; // queue for proxied functions before script load
   this._sending = false;


### PR DESCRIPTION
### Summary

Creates clone of nested objects in `DEFAULT_OPTIONS` to break sharing of references to these nested objects

#### Testing
```
const a = amplitude.getInstance('a')
> undefined
const a = amplitude.getInstance('a')
> undefined
a.options.plan === b.options.plan
> false
a.options.library === b.options.library
> false
a.options.headers === b.options.headers
> false
a.options.ingestionMetadata === b.options.ingestionMetadata
> false
```

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-JavaScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
