### PR TITLE
fix: remove events when 200, no need to check response

### DIFF
--- a/src/amplitude-client.js
+++ b/src/amplitude-client.js
@@ -1916,7 +1916,7 @@ AmplitudeClient.prototype.sendEvents = function sendEvents() {
     new Request(url, data, this.options.headers).send(function (status, response) {
       scope._sending = false;
       try {
-        if (status === 200 && response === 'success') {
+        if (status === 200) {
           scope.removeEvents(maxEventId, maxIdentifyId, status, response);
 
           // Update the event cache after the removal of sent events.


### PR DESCRIPTION
### Summary
- fix: remove events when 200, no need to check response

User might use the SDK to send events to their proxy server, we should only rely on the 200 status code, not the response content for removing successfully sent events. Otherwise, the same event might get sent to the ingestion host again and again.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-JavaScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
