### PR TITLE
fix: wait to create cookie storage based on user options in init()

### DIFF
--- a/src/amplitude-client.js
+++ b/src/amplitude-client.js
@@ -47,7 +47,6 @@ var AmplitudeClient = function AmplitudeClient(instanceName) {
     plan: { ...DEFAULT_OPTIONS.plan },
     trackingOptions: { ...DEFAULT_OPTIONS.trackingOptions },
   };
-  this.cookieStorage = new cookieStorage().getStorage();
   this._q = []; // queue for proxied functions before script load
   this._sending = false;
   this._updateScheduled = false;
@@ -127,6 +126,7 @@ AmplitudeClient.prototype.init = function init(apiKey, opt_userId, opt_config, o
 
     this._cookieName = Constants.COOKIE_PREFIX + '_' + this._storageSuffixV5;
 
+    this.cookieStorage = new cookieStorage().getStorage(this.options.disableCookies);
     this.cookieStorage.options({
       expirationDays: this.options.cookieExpiration,
       domain: this.options.domain,

--- a/src/cookiestorage.js
+++ b/src/cookiestorage.js
@@ -12,12 +12,12 @@ var cookieStorage = function () {
   this.storage = null;
 };
 
-cookieStorage.prototype.getStorage = function () {
+cookieStorage.prototype.getStorage = function (disableCookies) {
   if (this.storage !== null) {
     return this.storage;
   }
 
-  if (baseCookie.areCookiesEnabled()) {
+  if (!disableCookies && baseCookie.areCookiesEnabled()) {
     this.storage = Cookie;
   } else {
     // if cookies disabled, fallback to localstorage

--- a/test/amplitude-client.js
+++ b/test/amplitude-client.js
@@ -2777,25 +2777,6 @@ describe('AmplitudeClient', function () {
       assert.equal(cookieArray.length, 1);
     });
 
-    it('should not create any cookies if disabledCookies = true', function () {
-      deleteAllCookies();
-      clock.tick(20);
-
-      var cookieArray = getAllCookies();
-      assert.equal(cookieArray.length, 0);
-
-      var deviceId = 'test_device_id';
-      var amplitude2 = new AmplitudeClient();
-
-      amplitude2.init(apiKey, null, {
-        deviceId: deviceId,
-        disableCookies: true,
-      });
-
-      cookieArray = getAllCookies();
-      assert.equal(cookieArray.length, 0);
-    });
-
     it('should validate event properties', function () {
       var e = new Error('oops');
       clock.tick(1);

--- a/test/amplitude-client.js
+++ b/test/amplitude-client.js
@@ -888,11 +888,11 @@ describe('AmplitudeClient', function () {
       var onErrorSpy = sinon.spy();
 
       var amplitude = new AmplitudeClient();
-      sinon.stub(amplitude.cookieStorage, 'options').throws();
+      sinon.stub(amplitude, '_refreshDynamicConfig').throws();
       amplitude.init(apiKey, null, { onError: onErrorSpy });
       assert.isTrue(onErrorSpy.calledOnce);
 
-      amplitude.cookieStorage.options.restore();
+      amplitude['_refreshDynamicConfig'].restore();
     });
 
     it('should set observer plan options', function () {

--- a/test/amplitude-client.js
+++ b/test/amplitude-client.js
@@ -2728,6 +2728,35 @@ describe('AmplitudeClient', function () {
       });
     });
 
+    it('should not create any cookies if disabledCookies = true', function () {
+      const deleteAllCookies = () =>
+        document.cookie.split(';').forEach(function (c) {
+          document.cookie = c.replace(/^ +/, '').replace(/=.*/, '=;expires=' + new Date().toUTCString() + ';path=/');
+        });
+      const getAllCookies = () =>
+        document.cookie
+          .split(';')
+          .map((c) => c.trimStart())
+          .filter((c) => !utils.isEmptyString(c));
+
+      deleteAllCookies();
+      clock.tick(20);
+
+      var cookieArray = getAllCookies();
+      assert.equal(cookieArray.length, 0);
+
+      var deviceId = 'test_device_id';
+      var amplitude2 = new AmplitudeClient();
+
+      amplitude2.init(apiKey, null, {
+        deviceId: deviceId,
+        disableCookies: true,
+      });
+
+      cookieArray = getAllCookies();
+      assert.equal(cookieArray.length, 0);
+    });
+
     it('should validate event properties', function () {
       var e = new Error('oops');
       clock.tick(1);

--- a/test/amplitude-client.js
+++ b/test/amplitude-client.js
@@ -13,6 +13,17 @@ import { mockCookie, restoreCookie, getCookie } from './mock-cookie';
 import { AmplitudeServerZone } from '../src/server-zone.js';
 import Request from '../src/xhr';
 
+const deleteAllCookies = () =>
+  document.cookie.split(';').forEach(function (c) {
+    document.cookie = c.replace(/^ +/, '').replace(/=.*/, '=;expires=' + new Date().toUTCString() + ';path=/');
+  });
+
+const getAllCookies = () =>
+  document.cookie
+    .split(';')
+    .map((c) => c.trimStart())
+    .filter((c) => !utils.isEmptyString(c));
+
 // maintain for testing backwards compatability
 describe('AmplitudeClient', function () {
   var apiKey = '000000';
@@ -2729,16 +2740,44 @@ describe('AmplitudeClient', function () {
     });
 
     it('should not create any cookies if disabledCookies = true', function () {
-      const deleteAllCookies = () =>
-        document.cookie.split(';').forEach(function (c) {
-          document.cookie = c.replace(/^ +/, '').replace(/=.*/, '=;expires=' + new Date().toUTCString() + ';path=/');
-        });
-      const getAllCookies = () =>
-        document.cookie
-          .split(';')
-          .map((c) => c.trimStart())
-          .filter((c) => !utils.isEmptyString(c));
+      deleteAllCookies();
+      clock.tick(20);
 
+      var cookieArray = getAllCookies();
+      assert.equal(cookieArray.length, 0);
+
+      var deviceId = 'test_device_id';
+      var amplitude2 = new AmplitudeClient();
+
+      amplitude2.init(apiKey, null, {
+        deviceId: deviceId,
+        disableCookies: true,
+      });
+
+      cookieArray = getAllCookies();
+      assert.equal(cookieArray.length, 0);
+    });
+
+    it('should create cookies if disabledCookies = false', function () {
+      deleteAllCookies();
+      clock.tick(20);
+
+      var cookieArray = getAllCookies();
+      assert.equal(cookieArray.length, 0);
+
+      var deviceId = 'test_device_id';
+      var amplitude2 = new AmplitudeClient();
+
+      amplitude2.init(apiKey, null, {
+        deviceId: deviceId,
+        disableCookies: false,
+      });
+
+      cookieArray = getAllCookies();
+      assert.equal(cookieArray.length, 1);
+    });
+
+    it('should not create any cookies if disabledCookies = true', function () {
       deleteAllCookies();
       clock.tick(20);
 


### PR DESCRIPTION
### Summary

Delay creation of cookie storage to `init()` to honor `disableCookies` option to prevent creation of test cookie


### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-JavaScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
