### PR TITLE
fix: reset referring_domain

### DIFF
--- a/src/amplitude-client.js
+++ b/src/amplitude-client.js
@@ -761,6 +761,7 @@ AmplitudeClient.prototype._initUtmData = function _initUtmData(queryParams, cook
 AmplitudeClient.prototype._unsetUTMParams = function _unsetUTMParams() {
   var identify = new Identify();
   identify.unset(Constants.REFERRER);
+  identify.unset(Constants.REFERRING_DOMAIN);
   identify.unset(Constants.UTM_SOURCE);
   identify.unset(Constants.UTM_MEDIUM);
   identify.unset(Constants.UTM_CAMPAIGN);

--- a/src/constants.js
+++ b/src/constants.js
@@ -53,6 +53,7 @@ export default {
   AMP_REFERRER_PARAM: 'amp_referrer', // url param for overwriting the document.refer
 
   REFERRER: 'referrer',
+  REFERRING_DOMAIN: 'referring_domain',
 
   // UTM Params
   UTM_SOURCE: 'utm_source',

--- a/test/amplitude-client.js
+++ b/test/amplitude-client.js
@@ -3394,6 +3394,7 @@ describe('AmplitudeClient', function () {
         {
           $unset: {
             referrer: '-',
+            referring_domain: '-',
             utm_source: '-',
             utm_medium: '-',
             utm_campaign: '-',
@@ -3483,6 +3484,7 @@ describe('AmplitudeClient', function () {
         {
           $unset: {
             referrer: '-',
+            referring_domain: '-',
             utm_source: '-',
             utm_medium: '-',
             utm_campaign: '-',


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude JavaScript SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

<!-- What does the PR do? -->

`unsetParamsReferrerOnNewSession` should also reset `referring_domain` by [definition](https://www.docs.developers.amplitude.com/data/sdks/javascript/#track-referrers). 

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-JavaScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
