### PR TITLE
chore: use npm exec for semantic-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,11 +97,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           S3_BUCKET_NAME: ${{ secrets.S3_BUCKET_NAME }}
-        run: npx semantic-release --dry-run
+        run: npm exec semantic-release -- --dry-run
 
       - name: Release # Uses release.config.js
         if: ${{ github.event.inputs.releaseType == 'release' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           S3_BUCKET_NAME: ${{ secrets.S3_BUCKET_NAME }}
-        run: npx semantic-release
+        run: npm exec semantic-release


### PR DESCRIPTION
Applies the equivalent release-command modernization from amplitude/Amplitude-Swift#350 for this repository setup.

## Changes
- replace `npx semantic-release --dry-run` with `npm exec semantic-release -- --dry-run`
- replace `npx semantic-release` with `npm exec semantic-release`

This repo already installs dependencies from `yarn.lock` (`yarn install --frozen-lockfile`), so no additional lockfile changes are required.
